### PR TITLE
[197] Add LaTeX preview in question editor and assessment lifecycle controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 .cache/
 *.pem
 .claude
+venv/

--- a/package-lock.json
+++ b/package-lock.json
@@ -2168,30 +2168,6 @@
         "react-scripts": "*"
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -5383,34 +5359,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -5692,7 +5640,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -7166,9 +7113,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -7929,13 +7876,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8740,16 +8680,6 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
-    },
-    "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
     },
     "node_modules/diff-sequences": {
       "version": "27.5.1",
@@ -9984,9 +9914,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -13151,9 +13081,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -13248,13 +13178,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -14042,9 +13965,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -19022,6 +18945,7 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -19164,9 +19088,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -19174,7 +19098,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -19439,13 +19363,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -19649,6 +19566,7 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -19904,9 +19822,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/webpack-dev-server/node_modules/qs": {
@@ -20713,16 +20631,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
+++ b/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
@@ -4,14 +4,28 @@ import MCQEditor from './MCQEditor';
 import StructuredQuestionBuilder from './StructuredQuestionBuilder';
 import StimulusUploader from './StimulusUploader';
 import AIBulkGenerator from './AIBulkGenerator';
+import LaTeXRenderer from '../LaTeXRenderer';
 
-const QuestionEditor = ({ 
-  question, 
-  questionIndex, 
-  onQuestionChange, 
-  onRemove, 
+// Inline LaTeX preview shown automatically when the field contains $ delimiters
+const LaTeXPreview = ({ text, label }) => {
+  if (!text || !text.includes('$')) return null;
+  return (
+    <div className="mt-1 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+      <p className="text-xs text-blue-600 font-medium mb-1">LaTeX preview — {label}</p>
+      <div className="text-sm text-gray-900">
+        <LaTeXRenderer text={text} />
+      </div>
+    </div>
+  );
+};
+
+const QuestionEditor = ({
+  question,
+  questionIndex,
+  onQuestionChange,
+  onRemove,
   assessmentMode,
-  assessmentId 
+  assessmentId
 }) => {
   const [activeTab, setActiveTab] = useState('manual'); // 'manual' or 'ai'
 
@@ -21,14 +35,13 @@ const QuestionEditor = ({
 
   const handleAIQuestionsGenerated = (questions) => {
     if (questions && questions.length > 0) {
-      // Take the first question and populate the current question
       const aiQuestion = questions[0];
       onQuestionChange(questionIndex, {
         ...question,
         ...aiQuestion,
-        questionNumber: question.questionNumber // Preserve the question number
+        questionNumber: question.questionNumber
       });
-      setActiveTab('manual'); // Switch to manual to see the result
+      setActiveTab('manual');
     }
   };
 
@@ -51,7 +64,6 @@ const QuestionEditor = ({
     }
   };
 
-  // Auto-initialize based on question type
   React.useEffect(() => {
     if (question.questionType === 'MULTIPLE_CHOICE' || question.questionType === 'MULTI_SELECT') {
       initializeMCQOptions();
@@ -139,16 +151,20 @@ const QuestionEditor = ({
 
                 {/* Question Body */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    Question Text
-                  </label>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="block text-sm font-medium text-gray-700">
+                      Question Text
+                    </label>
+                    <span className="text-xs text-gray-400">Use $…$ for inline LaTeX, $$…$$ for display</span>
+                  </div>
                   <textarea
                     value={question.questionBody || ''}
                     onChange={(e) => updateQuestion('questionBody', e.target.value)}
-                    placeholder="Enter your question here..."
+                    placeholder="Enter your question here... Use $x^2$ for inline LaTeX or $$\frac{a}{b}$$ for display math"
                     rows={3}
                     className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                   />
+                  <LaTeXPreview text={question.questionBody} label="question" />
                 </div>
 
                 {/* MCQ Options */}
@@ -167,7 +183,6 @@ const QuestionEditor = ({
                     parts={question.parts || []}
                     onPartsChange={(parts) => {
                       updateQuestion('parts', parts);
-                      // Auto-calculate total marks
                       const totalMarks = parts.reduce((sum, p) => sum + (p.maxMarks || 0), 0);
                       updateQuestion('maxMarks', totalMarks);
                     }}
@@ -206,18 +221,25 @@ const QuestionEditor = ({
                     </div>
 
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Mark Scheme</label>
+                      <div className="flex items-center justify-between mb-1">
+                        <label className="block text-sm font-medium text-gray-700">Mark Scheme</label>
+                        <span className="text-xs text-gray-400">Supports LaTeX ($…$)</span>
+                      </div>
                       <textarea
                         value={question.markScheme || ''}
                         onChange={(e) => updateQuestion('markScheme', e.target.value)}
-                        placeholder="Enter marking criteria..."
+                        placeholder="Enter marking criteria... e.g. Award 1 mark for $x = \frac{-b \pm \sqrt{b^2-4ac}}{2a}$"
                         rows={3}
                         className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                       />
+                      <LaTeXPreview text={question.markScheme} label="mark scheme" />
                     </div>
 
                     <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">Model Answer (Optional)</label>
+                      <div className="flex items-center justify-between mb-1">
+                        <label className="block text-sm font-medium text-gray-700">Model Answer (Optional)</label>
+                        <span className="text-xs text-gray-400">Supports LaTeX ($…$)</span>
+                      </div>
                       <textarea
                         value={question.modelAnswer || ''}
                         onChange={(e) => updateQuestion('modelAnswer', e.target.value)}
@@ -225,6 +247,7 @@ const QuestionEditor = ({
                         rows={2}
                         className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                       />
+                      <LaTeXPreview text={question.modelAnswer} label="model answer" />
                     </div>
                   </>
                 )}
@@ -252,7 +275,7 @@ const QuestionEditor = ({
               assessmentMode={assessmentMode}
             />
             <div className="mt-4 bg-blue-50 border border-blue-200 rounded-lg p-3 text-sm text-blue-800">
-              💡 AI will generate a question based on your specifications. You can edit it after generation.
+              AI will generate a question based on your specifications. You can edit it after generation.
             </div>
           </div>
         )}

--- a/src/components/EnhancedAssessmentBuilder/StructuredQuestionBuilder.js
+++ b/src/components/EnhancedAssessmentBuilder/StructuredQuestionBuilder.js
@@ -1,5 +1,17 @@
-import React, { useState } from 'react';
+import React from 'react';
 import LaTeXRenderer from '../LaTeXRenderer';
+
+const LaTeXPreview = ({ text, label }) => {
+  if (!text || !text.includes('$')) return null;
+  return (
+    <div className="mt-1 p-2 bg-blue-50 border border-blue-200 rounded-lg">
+      <p className="text-xs text-blue-600 font-medium mb-1">Preview — {label}</p>
+      <div className="text-sm text-gray-900">
+        <LaTeXRenderer text={text} />
+      </div>
+    </div>
+  );
+};
 
 const StructuredQuestionBuilder = ({ parts, onPartsChange, questionNumber }) => {
   const getNextPartLabel = () => {
@@ -94,16 +106,20 @@ const StructuredQuestionBuilder = ({ parts, onPartsChange, questionNumber }) => 
                 <div className="flex-1 space-y-3">
                   {/* Part Prompt */}
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      Part ({part.partLabel}) Question
-                    </label>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-sm font-medium text-gray-700">
+                        Part ({part.partLabel}) Question
+                      </label>
+                      <span className="text-xs text-gray-400">Supports LaTeX ($…$)</span>
+                    </div>
                     <textarea
                       value={part.partPrompt}
                       onChange={(e) => updatePart(index, 'partPrompt', e.target.value)}
-                      placeholder="Enter the question for this part..."
+                      placeholder="Enter the question for this part... e.g. Solve $2x^2 - 5x + 3 = 0$"
                       rows={2}
                       className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                     />
+                    <LaTeXPreview text={part.partPrompt} label={`part ${part.partLabel}`} />
                   </div>
 
                   {/* Marks and Answer Type */}
@@ -136,7 +152,10 @@ const StructuredQuestionBuilder = ({ parts, onPartsChange, questionNumber }) => 
 
                   {/* Mark Scheme */}
                   <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">Mark Scheme</label>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-sm font-medium text-gray-700">Mark Scheme</label>
+                      <span className="text-xs text-gray-400">Supports LaTeX ($…$)</span>
+                    </div>
                     <textarea
                       value={part.markScheme}
                       onChange={(e) => updatePart(index, 'markScheme', e.target.value)}
@@ -144,6 +163,7 @@ const StructuredQuestionBuilder = ({ parts, onPartsChange, questionNumber }) => 
                       rows={2}
                       className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                     />
+                    <LaTeXPreview text={part.markScheme} label={`part ${part.partLabel} mark scheme`} />
                   </div>
                 </div>
 

--- a/src/components/TeacherPages.js
+++ b/src/components/TeacherPages.js
@@ -139,12 +139,22 @@ export const AssessmentsPage = ({ user }) => {
   };
 
   const handleClose = async (id) => {
-    if (!window.confirm("Close this assessment?")) return;
+    if (!window.confirm("Close this assessment? Students will no longer be able to join.")) return;
     try {
       await axios.post(`${API}/teacher/assessments/${id}/close`);
       loadData();
     } catch (error) {
       handleApiError(error, "Failed to close assessment");
+    }
+  };
+
+  const handleReopen = async (id) => {
+    if (!window.confirm("Reopen this assessment? It will be set back to Draft so you can edit it.")) return;
+    try {
+      await axios.post(`${API}/teacher/assessments/${id}/reopen`);
+      loadData();
+    } catch (error) {
+      handleApiError(error, "Failed to reopen assessment");
     }
   };
 
@@ -743,8 +753,8 @@ export const AssessmentsPage = ({ user }) => {
                           )}
                         </div>
                       </div>
-                      <div className="flex gap-2">
-                        {a.status === "draft" && (
+                      <div className="flex gap-2 flex-wrap">
+                        {(a.status === "draft" || a.status === "published") && (
                           <button
                             onClick={() => handleStart(a.id)}
                             className="bg-green-600 text-white py-1 px-3 rounded text-sm hover:bg-green-700"
@@ -753,13 +763,13 @@ export const AssessmentsPage = ({ user }) => {
                             Start Assessment
                           </button>
                         )}
-                        {a.status === "published" && (
+                        {(a.status === "draft" || a.status === "published") && isEnhanced && (
                           <button
-                            onClick={() => handleStart(a.id)}
-                            className="bg-green-600 text-white py-1 px-3 rounded text-sm hover:bg-green-700"
-                            data-testid={`start-assessment-${a.id}`}
+                            onClick={() => navigate(`/teacher/assessments/${a.id}/edit`)}
+                            className="bg-gray-600 text-white py-1 px-3 rounded text-sm hover:bg-gray-700"
+                            data-testid={`edit-assessment-${a.id}`}
                           >
-                            Start Assessment
+                            Edit
                           </button>
                         )}
                         {a.status === "started" && (
@@ -771,9 +781,17 @@ export const AssessmentsPage = ({ user }) => {
                             Close Assessment
                           </button>
                         )}
+                        {a.status === "closed" && (
+                          <button
+                            onClick={() => handleReopen(a.id)}
+                            className="bg-yellow-600 text-white py-1 px-3 rounded text-sm hover:bg-yellow-700"
+                            data-testid={`reopen-assessment-${a.id}`}
+                          >
+                            Reopen
+                          </button>
+                        )}
                         <button
                           onClick={() => {
-                            // Redirect to Enhanced detail page if it's an Enhanced Assessment
                             if (isEnhanced) {
                               navigate(`/teacher/assessments/${a.id}/enhanced`);
                             } else {

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -49,7 +49,21 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   const loadAssessment = async () => {
     try {
       const response = await axios.get(`${API}/teacher/assessments/${assessmentId}/enhanced`);
-      setAssessmentData(response.data.assessment);
+      const assessment = response.data.assessment;
+
+      if (assessment.status === 'closed') {
+        showNotification('This assessment is closed. Reopen it from the Assessments list before editing.', 'error');
+        setTimeout(() => navigate('/teacher/assessments'), 2000);
+        return;
+      }
+
+      if (assessment.status === 'started') {
+        showNotification('This assessment is live and cannot be edited while students are taking it.', 'error');
+        setTimeout(() => navigate('/teacher/assessments'), 2000);
+        return;
+      }
+
+      setAssessmentData(assessment);
       setCurrentStep(3);
       setLoading(false);
     } catch (error) {


### PR DESCRIPTION
Added:
- `LaTeXRenderer` into `QuestionEditor.js` and `StructuredQuestionBuilder.js` so teachers see a live rendered preview below any field containing `$…$` while they type
- Adds status guards to `EnhancedAssessmentBuilderPage.js` that redirect away with an error if a teacher tries to edit a started or closed assessment
- Updated `TeacherPages.js` with a `handleReopen` handler, a yellow Reopen button for closed assessments and an Edit button for draft/published enhanced assessments navigating to the builder