### PR TITLE
Feature/205 maths keyboard update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "katex": "^0.16.28",
         "lucide-react": "^0.507.0",
         "mathjs": "^15.1.1",
+        "mathlive": "^0.109.1",
         "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-day-picker": "^9.6.7",
@@ -2146,6 +2147,20 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
+    },
+    "node_modules/@cortex-js/compute-engine": {
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/@cortex-js/compute-engine/-/compute-engine-0.30.2.tgz",
+      "integrity": "sha512-Zx+iisk9WWdbxjm8EYsneIBszvjfUs7BHNwf1jBtSINIgfWGpHrTTq9vW0J59iGCFt6bOFxbmWyxNMRSmksHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "complex-esm": "^2.1.1-esm1",
+        "decimal.js": "^10.6.0"
+      },
+      "engines": {
+        "node": ">=21.7.3",
+        "npm": ">=10.5.0"
+      }
     },
     "node_modules/@craco/craco": {
       "version": "5.9.0",
@@ -7670,6 +7685,16 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "license": "MIT"
+    },
+    "node_modules/complex-esm": {
+      "version": "2.1.1-esm1",
+      "resolved": "https://registry.npmjs.org/complex-esm/-/complex-esm-2.1.1-esm1.tgz",
+      "integrity": "sha512-IShBEWHILB9s7MnfyevqNGxV0A1cfcSnewL/4uPFiSxkcQL4Mm3FxJ0pXMtCXuWLjYz3lRRyk6OfkeDZcjD6nw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.14.2",
+        "npm": ">=8.5.0"
+      }
     },
     "node_modules/complex.js": {
       "version": "2.4.3",
@@ -13218,6 +13243,19 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/mathlive": {
+      "version": "0.109.1",
+      "resolved": "https://registry.npmjs.org/mathlive/-/mathlive-0.109.1.tgz",
+      "integrity": "sha512-TXNkTzdJnk/6SFt0Oezy3bpZkH7aCDriuh2usLhVX8dMS5TMmx/rLd7+T1W2b9VCbEZcXABzhmm6ZMxYr8sFXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cortex-js/compute-engine": "0.30.2"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paypal.me/arnogourdol"
       }
     },
     "node_modules/mdn-data": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "katex": "^0.16.28",
     "lucide-react": "^0.507.0",
     "mathjs": "^15.1.1",
+    "mathlive": "^0.109.1",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-day-picker": "^9.6.7",

--- a/src/components/AIQuestionGenerator.js
+++ b/src/components/AIQuestionGenerator.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
-import MathKeyboard from './MathKeyboard';
+import MixedMathEditor from './MixedMathEditor';
 import LaTeXRenderer from './LaTeXRenderer';
 import { API } from '@/config';
 import { getApiErrorMessage } from '@/lib/handle-error';
@@ -50,8 +50,6 @@ const AIQuestionGenerator = ({ user, onQuestionsGenerated }) => {
   const [generatedQuestions, setGeneratedQuestions] = useState([]);
   const [selectedQuestions, setSelectedQuestions] = useState(new Set());
   const [error, setError] = useState('');
-  const [showMathKeyboard, setShowMathKeyboard] = useState(false);
-  const [activeField, setActiveField] = useState(null);
 
   const handleChange = (field, value) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -139,17 +137,6 @@ const AIQuestionGenerator = ({ user, onQuestionsGenerated }) => {
       setSelectedQuestions(new Set());
     } catch (err) {
       setError('Failed to save questions');
-    }
-  };
-
-  const openMathKeyboard = (field) => {
-    setActiveField(field);
-    setShowMathKeyboard(true);
-  };
-
-  const insertMath = (latex) => {
-    if (activeField) {
-      handleChange(activeField, formData[activeField] + latex);
     }
   };
 
@@ -244,23 +231,13 @@ const AIQuestionGenerator = ({ user, onQuestionsGenerated }) => {
           {/* Topic */}
           <div className="md:col-span-2">
             <label className="block text-sm font-medium text-gray-700 mb-1">Topic *</label>
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={formData.topic}
-                onChange={(e) => handleChange('topic', e.target.value)}
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg"
-                placeholder="e.g., Quadratic equations"
-                data-testid="ai-topic"
-              />
-              <button
-                onClick={() => openMathKeyboard('topic')}
-                className="px-3 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg"
-                title="Math Keyboard"
-              >
-                𝑓(𝑥)
-              </button>
-            </div>
+            <MixedMathEditor
+              value={formData.topic}
+              onChange={(v) => handleChange('topic', v)}
+              placeholder="e.g., Quadratic equations"
+              rows={1}
+              data-testid="ai-topic"
+            />
           </div>
 
           {/* Subtopic */}
@@ -531,13 +508,6 @@ const AIQuestionGenerator = ({ user, onQuestionsGenerated }) => {
         </div>
       )}
 
-      {/* Math Keyboard Modal */}
-      {showMathKeyboard && (
-        <MathKeyboard
-          onInsert={insertMath}
-          onClose={() => setShowMathKeyboard(false)}
-        />
-      )}
     </div>
   );
 };

--- a/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
+++ b/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
@@ -4,20 +4,10 @@ import MCQEditor from './MCQEditor';
 import StructuredQuestionBuilder from './StructuredQuestionBuilder';
 import StimulusUploader from './StimulusUploader';
 import AIBulkGenerator from './AIBulkGenerator';
-import LaTeXRenderer from '../LaTeXRenderer';
+import MixedMathEditor from '../MixedMathEditor';
 
-// Inline LaTeX preview shown automatically when the field contains $ delimiters
-const LaTeXPreview = ({ text, label }) => {
-  if (!text || !text.includes('$')) return null;
-  return (
-    <div className="mt-1 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-      <p className="text-xs text-blue-600 font-medium mb-1">LaTeX preview — {label}</p>
-      <div className="text-sm text-gray-900">
-        <LaTeXRenderer text={text} />
-      </div>
-    </div>
-  );
-};
+const LONG_RESPONSE_MIN_MARKS = 6;
+const LONG_RESPONSE_MAX_MARKS = 15;
 
 const QuestionEditor = ({
   question,
@@ -55,6 +45,21 @@ const QuestionEditor = ({
       ]);
     }
   };
+
+  const getMarksConfig = () => {
+    if (question.questionType === 'LONG_RESPONSE') {
+      return { min: LONG_RESPONSE_MIN_MARKS, max: LONG_RESPONSE_MAX_MARKS };
+    }
+    return { min: 1, max: 20 };
+  };
+
+  const handleMarksChange = (val) => {
+    updateQuestion('maxMarks', parseInt(val) || 1);
+  };
+
+  const marksOutOfRange =
+    question.questionType === 'LONG_RESPONSE' &&
+    (question.maxMarks < LONG_RESPONSE_MIN_MARKS || question.maxMarks > LONG_RESPONSE_MAX_MARKS);
 
   const initializeStructuredParts = () => {
     if (!question.parts || question.parts.length === 0) {
@@ -131,7 +136,13 @@ const QuestionEditor = ({
                 <h4 className="font-medium text-gray-900 mb-3">Select Question Type</h4>
                 <QuestionTypeSelector
                   selectedType={question.questionType}
-                  onTypeChange={(type) => updateQuestion('questionType', type)}
+                  onTypeChange={(type) => {
+                    onQuestionChange(questionIndex, {
+                      ...question,
+                      questionType: type,
+                      maxMarks: type === 'LONG_RESPONSE' ? LONG_RESPONSE_MIN_MARKS : question.maxMarks
+                    });
+                  }}
                   mode={assessmentMode}
                 />
               </div>
@@ -151,20 +162,13 @@ const QuestionEditor = ({
 
                 {/* Question Body */}
                 <div>
-                  <div className="flex items-center justify-between mb-1">
-                    <label className="block text-sm font-medium text-gray-700">
-                      Question Text
-                    </label>
-                    <span className="text-xs text-gray-400">Use $…$ for inline LaTeX, $$…$$ for display</span>
-                  </div>
-                  <textarea
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Question Text</label>
+                  <MixedMathEditor
                     value={question.questionBody || ''}
-                    onChange={(e) => updateQuestion('questionBody', e.target.value)}
-                    placeholder="Enter your question here... Use $x^2$ for inline LaTeX or $$\frac{a}{b}$$ for display math"
+                    onChange={(v) => updateQuestion('questionBody', v)}
+                    placeholder="Enter your question here..."
                     rows={3}
-                    className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                   />
-                  <LaTeXPreview text={question.questionBody} label="question" />
                 </div>
 
                 {/* MCQ Options */}
@@ -195,15 +199,27 @@ const QuestionEditor = ({
                   <>
                     <div className="grid grid-cols-2 gap-4">
                       <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">Marks</label>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">
+                          Marks
+                          {question.questionType === 'LONG_RESPONSE' && (
+                            <span className="ml-1 text-xs text-blue-600 font-normal">(6–15 required)</span>
+                          )}
+                        </label>
                         <input
                           type="number"
-                          min="1"
-                          max="20"
+                          min={getMarksConfig().min}
+                          max={getMarksConfig().max}
                           value={question.maxMarks || 1}
-                          onChange={(e) => updateQuestion('maxMarks', parseInt(e.target.value) || 1)}
-                          className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+                          onChange={(e) => handleMarksChange(e.target.value)}
+                          className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 ${
+                            marksOutOfRange ? 'border-red-400 bg-red-50' : ''
+                          }`}
                         />
+                        {marksOutOfRange && (
+                          <p className="mt-1 text-xs text-red-600">
+                            Long response questions must be {LONG_RESPONSE_MIN_MARKS}–{LONG_RESPONSE_MAX_MARKS} marks.
+                          </p>
+                        )}
                       </div>
                       <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">Answer Type</label>
@@ -221,33 +237,23 @@ const QuestionEditor = ({
                     </div>
 
                     <div>
-                      <div className="flex items-center justify-between mb-1">
-                        <label className="block text-sm font-medium text-gray-700">Mark Scheme</label>
-                        <span className="text-xs text-gray-400">Supports LaTeX ($…$)</span>
-                      </div>
-                      <textarea
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Mark Scheme</label>
+                      <MixedMathEditor
                         value={question.markScheme || ''}
-                        onChange={(e) => updateQuestion('markScheme', e.target.value)}
-                        placeholder="Enter marking criteria... e.g. Award 1 mark for $x = \frac{-b \pm \sqrt{b^2-4ac}}{2a}$"
+                        onChange={(v) => updateQuestion('markScheme', v)}
+                        placeholder="Enter marking criteria..."
                         rows={3}
-                        className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                       />
-                      <LaTeXPreview text={question.markScheme} label="mark scheme" />
                     </div>
 
                     <div>
-                      <div className="flex items-center justify-between mb-1">
-                        <label className="block text-sm font-medium text-gray-700">Model Answer (Optional)</label>
-                        <span className="text-xs text-gray-400">Supports LaTeX ($…$)</span>
-                      </div>
-                      <textarea
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Model Answer (Optional)</label>
+                      <MixedMathEditor
                         value={question.modelAnswer || ''}
-                        onChange={(e) => updateQuestion('modelAnswer', e.target.value)}
+                        onChange={(v) => updateQuestion('modelAnswer', v)}
                         placeholder="Enter model answer for reference..."
                         rows={2}
-                        className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
                       />
-                      <LaTeXPreview text={question.modelAnswer} label="model answer" />
                     </div>
                   </>
                 )}
@@ -280,6 +286,7 @@ const QuestionEditor = ({
           </div>
         )}
       </div>
+
     </div>
   );
 };

--- a/src/components/MathEquationEditor.js
+++ b/src/components/MathEquationEditor.js
@@ -1,0 +1,176 @@
+import React, { useEffect, useRef, useState } from 'react';
+import 'mathlive';
+
+const SHORTCUTS = [
+  { key: '//', label: 'Fraction', example: 'a//b → a/b' },
+  { key: '^', label: 'Power', example: 'x^2 → x²' },
+  { key: '_', label: 'Subscript', example: 'x_1 → x₁' },
+  { key: 'sqrt', label: 'Square root', example: 'sqrt → √' },
+  { key: 'pi', label: 'Pi', example: 'pi → π' },
+  { key: 'inf', label: 'Infinity', example: 'inf → ∞' },
+];
+
+const MathEquationEditor = ({ onInsert, onClose }) => {
+  const mathFieldRef = useRef(null);
+  const [displayMode, setDisplayMode] = useState('inline');
+  const [isEmpty, setIsEmpty] = useState(true);
+
+  useEffect(() => {
+    const mf = mathFieldRef.current;
+    if (!mf) return;
+
+    const init = () => {
+      // Disable the global virtual keyboard (appears at bottom of screen by default)
+      mf.mathVirtualKeyboardPolicy = 'manual';
+
+      const handleInput = () => {
+        setIsEmpty(!mf.value || mf.value.trim() === '');
+      };
+      mf.addEventListener('input', handleInput);
+
+      try { mf.focus(); } catch (_) {}
+
+      return handleInput;
+    };
+
+    // Delay until the web component is fully defined and upgraded
+    let handleInput;
+    if (customElements.get('math-field')) {
+      handleInput = init();
+    } else {
+      const timer = setTimeout(() => {
+        handleInput = init();
+      }, 100);
+      return () => clearTimeout(timer);
+    }
+
+    return () => {
+      if (handleInput) mf.removeEventListener('input', handleInput);
+    };
+  }, []);
+
+  const handleInsert = () => {
+    const mf = mathFieldRef.current;
+    const latex = mf?.value || '';
+    if (!latex.trim()) return;
+    const wrapped = displayMode === 'display' ? `$$${latex}$$` : `$${latex}$`;
+    onInsert(wrapped);
+    onClose();
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+      handleInsert();
+    }
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-xl" onKeyDown={handleKeyDown}>
+        {/* Header */}
+        <div className="px-6 py-4 border-b flex justify-between items-center">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Insert Equation</h3>
+            <p className="text-xs text-gray-500 mt-0.5">Type your equation — it renders as you type</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 p-1 rounded hover:bg-gray-100"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Math field */}
+        <div className="px-6 pt-5 pb-3">
+          <div className="border-2 border-blue-400 rounded-xl p-4 bg-blue-50 min-h-[80px] flex items-center cursor-text"
+            onClick={() => mathFieldRef.current?.focus()}
+          >
+            <math-field
+              ref={mathFieldRef}
+              style={{
+                width: '100%',
+                fontSize: '1.6rem',
+                background: 'transparent',
+                border: 'none',
+                outline: 'none',
+              }}
+            />
+          </div>
+          {isEmpty && (
+            <p className="text-xs text-blue-500 mt-1 pl-1">
+              Click here and start typing your equation (e.g. type <code className="bg-blue-100 px-1 rounded">x^2+2x+1</code>)
+            </p>
+          )}
+        </div>
+
+        {/* Display mode */}
+        <div className="px-6 pb-4 flex items-center gap-3">
+          <span className="text-xs text-gray-500 font-medium">Style:</span>
+          <button
+            onClick={() => setDisplayMode('inline')}
+            className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+              displayMode === 'inline'
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+            }`}
+          >
+            Inline
+          </button>
+          <button
+            onClick={() => setDisplayMode('display')}
+            className={`px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+              displayMode === 'display'
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+            }`}
+          >
+            Centred / Large
+          </button>
+        </div>
+
+        {/* Shortcut hints */}
+        <div className="mx-6 mb-4 p-3 bg-gray-50 rounded-xl border border-gray-200">
+          <p className="text-xs text-gray-500 font-medium mb-2">Shortcuts</p>
+          <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+            {SHORTCUTS.map((s) => (
+              <div key={s.key} className="text-xs text-gray-600">
+                <code className="bg-gray-200 px-1 py-0.5 rounded text-gray-800">{s.example}</code>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t bg-gray-50 rounded-b-2xl flex justify-between items-center">
+          <span className="text-xs text-gray-400">Ctrl+Enter to insert</span>
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-600 hover:text-gray-900 font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleInsert}
+              disabled={isEmpty}
+              className="px-5 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Insert Equation
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MathEquationEditor;

--- a/src/components/MixedMathEditor.js
+++ b/src/components/MixedMathEditor.js
@@ -1,15 +1,8 @@
 import React, { useRef, useState, useEffect } from 'react';
 import 'mathlive';
 import LaTeXRenderer from './LaTeXRenderer';
+import MathKeyboard from './MathKeyboard';
 
-/**
- * MixedMathEditor
- * A textarea for prose combined with a MathLive WYSIWYG equation bar.
- * Teachers type text normally; when they need a math expression they click
- * "∑ Equation", type into the visual MathLive field (equations render live
- * exactly like Desmos), then click "Insert" to drop it at cursor position.
- * A KaTeX preview below shows the final rendered output.
- */
 const MixedMathEditor = ({
   value,
   onChange,
@@ -21,28 +14,39 @@ const MixedMathEditor = ({
   const textareaRef = useRef(null);
   const mathFieldRef = useRef(null);
   const [showMathBar, setShowMathBar] = useState(false);
+  const [showSymbols, setShowSymbols] = useState(false);
   const [mathIsEmpty, setMathIsEmpty] = useState(true);
   const [cursorPos, setCursorPos] = useState(null);
 
-  // Set up MathLive field whenever the bar opens
   useEffect(() => {
     if (!showMathBar) return;
 
     let handler;
-
     const setup = () => {
       const mf = mathFieldRef.current;
       if (!mf) return;
-      // Disable bottom-of-screen virtual keyboard
+
+      // Suppress MathLive's virtual keyboard entirely — we rely on physical keyboard only
       mf.mathVirtualKeyboardPolicy = 'manual';
-      // Reset on open
+      try { window.mathVirtualKeyboard?.hide(); } catch (_) {}
+
       mf.value = '';
       setMathIsEmpty(true);
-
       handler = () => setMathIsEmpty(!mf.value || mf.value.trim() === '');
       mf.addEventListener('input', handler);
 
+      // Also hide on focus in case the browser triggers it
+      const onFocus = () => { try { window.mathVirtualKeyboard?.hide(); } catch (_) {} };
+      mf.addEventListener('focusin', onFocus);
+
       setTimeout(() => { try { mf.focus(); } catch (_) {} }, 60);
+
+      // Return cleanup that removes both listeners
+      const origHandler = handler;
+      handler = () => {
+        origHandler();
+      };
+      mf._mixedEditorFocusHandler = onFocus;
     };
 
     if (customElements.get('math-field')) {
@@ -54,7 +58,12 @@ const MixedMathEditor = ({
 
     return () => {
       const mf = mathFieldRef.current;
-      if (mf && handler) mf.removeEventListener('input', handler);
+      if (!mf) return;
+      if (handler) mf.removeEventListener('input', handler);
+      if (mf._mixedEditorFocusHandler) {
+        mf.removeEventListener('focusin', mf._mixedEditorFocusHandler);
+        delete mf._mixedEditorFocusHandler;
+      }
     };
   }, [showMathBar]);
 
@@ -62,31 +71,13 @@ const MixedMathEditor = ({
     if (textareaRef.current) setCursorPos(textareaRef.current.selectionStart);
   };
 
-  const openMathBar = () => {
-    saveCursor();
-    setShowMathBar(true);
-  };
-
-  const closeMathBar = () => {
-    setShowMathBar(false);
-    textareaRef.current?.focus();
-  };
-
-  const insertEquation = () => {
-    const mf = mathFieldRef.current;
-    const latex = mf?.value?.trim() || '';
-    if (!latex) return;
-
-    const snippet = `$${latex}$ `;
+  const insertAtCursor = (snippet) => {
     const pos = cursorPos ?? (value || '').length;
     const before = (value || '').slice(0, pos);
     const after = (value || '').slice(pos);
-    // Add a space before the snippet only if the char before cursor isn't already a space
     const sep = before.length > 0 && !before.endsWith(' ') ? ' ' : '';
     const newValue = before + sep + snippet + after;
     onChange(newValue);
-
-    setShowMathBar(false);
 
     setTimeout(() => {
       if (textareaRef.current) {
@@ -98,16 +89,51 @@ const MixedMathEditor = ({
     }, 30);
   };
 
-  const handleKeyDown = (e) => {
+  const insertEquation = () => {
+    const mf = mathFieldRef.current;
+    const latex = mf?.value?.trim() || '';
+    if (!latex) return;
+    insertAtCursor(`$${latex}$ `);
+    try { window.mathVirtualKeyboard?.hide(); } catch (_) {}
+    try { mf?.blur(); } catch (_) {}
+    setShowMathBar(false);
+  };
+
+  const insertSymbol = (latex) => {
+    // latex already arrives wrapped as $...$ from MathKeyboard
+    insertAtCursor(latex + ' ');
+    setShowSymbols(false);
+  };
+
+  const closeMathBar = () => {
+    // Explicitly dismiss MathLive's virtual keyboard before unmounting the field
+    try { window.mathVirtualKeyboard?.hide(); } catch (_) {}
+    try { mathFieldRef.current?.blur(); } catch (_) {}
+    setShowMathBar(false);
+    textareaRef.current?.focus();
+  };
+
+  const handleMathBarKeyDown = (e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') insertEquation();
     if (e.key === 'Escape') closeMathBar();
+  };
+
+  const openMathBar = () => {
+    saveCursor();
+    setShowMathBar(true);
+    setShowSymbols(false);
+  };
+
+  const openSymbols = () => {
+    saveCursor();
+    setShowSymbols(true);
   };
 
   const hasPreview = value && value.includes('$');
 
   return (
     <div className="space-y-1.5">
-      {/* Textarea */}
+      {/* Textarea with button toolbar */}
       <div className="relative">
         <textarea
           ref={textareaRef}
@@ -120,37 +146,66 @@ const MixedMathEditor = ({
           rows={rows}
           required={required}
           data-testid={testId}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y pr-28 text-sm"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y pr-44 text-sm"
         />
-        <button
-          type="button"
-          onClick={openMathBar}
-          className={`absolute top-2 right-2 flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors border ${
-            showMathBar
-              ? 'bg-blue-600 text-white border-blue-600'
-              : 'bg-white text-blue-600 border-blue-300 hover:bg-blue-50'
-          }`}
-        >
-          ∑ Equation
-        </button>
+        {/* Two buttons top-right inside the textarea */}
+        <div className="absolute top-2 right-2 flex gap-1">
+          <button
+            type="button"
+            onClick={openMathBar}
+            className={`flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors border ${
+              showMathBar
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-blue-600 border-blue-300 hover:bg-blue-50'
+            }`}
+            title="Insert rendered equation (WYSIWYG)"
+          >
+            ∑ Equation
+          </button>
+          <button
+            type="button"
+            onClick={openSymbols}
+            className="flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors border bg-white text-purple-600 border-purple-300 hover:bg-purple-50"
+            title="Insert symbol (Greek, Chemistry, Vectors…)"
+          >
+            αβ Symbols
+          </button>
+        </div>
       </div>
 
-      {/* Inline WYSIWYG math bar */}
+      {/* Inline WYSIWYG equation bar */}
       {showMathBar && (
-        <div className="rounded-xl border-2 border-blue-400 bg-blue-50 p-3 space-y-2" onKeyDown={handleKeyDown}>
+        <div
+          className="rounded-xl border-2 border-blue-400 bg-blue-50 p-3 space-y-2"
+          onKeyDown={handleMathBarKeyDown}
+        >
+          {/* Bar header with close button */}
           <div className="flex items-center justify-between">
-            <span className="text-xs font-semibold text-blue-700">
-              Type your equation — it renders as you type
-            </span>
-            <span className="text-xs text-blue-500">
-              Try: <code className="bg-blue-100 px-1 rounded">x^2</code>&nbsp;
-              <code className="bg-blue-100 px-1 rounded">a//b</code>&nbsp;
-              <code className="bg-blue-100 px-1 rounded">sqrt</code>&nbsp;
-              <code className="bg-blue-100 px-1 rounded">pi</code>
-            </span>
+            <div className="flex items-center gap-3">
+              <span className="text-xs font-semibold text-blue-700">
+                Type your equation — it renders as you type
+              </span>
+              <span className="text-xs text-blue-400 hidden sm:block">
+                Try:&nbsp;
+                <code className="bg-blue-100 px-1 rounded">x^2</code>&nbsp;
+                <code className="bg-blue-100 px-1 rounded">a//b</code>&nbsp;
+                <code className="bg-blue-100 px-1 rounded">sqrt</code>&nbsp;
+                <code className="bg-blue-100 px-1 rounded">pi</code>
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={closeMathBar}
+              className="ml-2 p-1 rounded-full text-blue-400 hover:text-blue-700 hover:bg-blue-100 transition-colors flex-shrink-0"
+              title="Close equation bar"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
 
-          {/* MathLive field */}
+          {/* MathLive field + Insert button */}
           <div className="flex gap-2 items-stretch">
             <div
               className="flex-1 bg-white border border-blue-200 rounded-lg px-3 py-2 cursor-text flex items-center min-h-[52px]"
@@ -167,25 +222,15 @@ const MixedMathEditor = ({
                 }}
               />
             </div>
-
-            <div className="flex flex-col gap-1">
-              <button
-                type="button"
-                onClick={insertEquation}
-                disabled={mathIsEmpty}
-                className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap flex-1"
-                title="Ctrl+Enter"
-              >
-                Insert ↑
-              </button>
-              <button
-                type="button"
-                onClick={closeMathBar}
-                className="px-4 py-2 bg-white border border-gray-200 text-gray-500 rounded-lg text-sm hover:text-gray-800"
-              >
-                Cancel
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={insertEquation}
+              disabled={mathIsEmpty}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap self-stretch"
+              title="Insert equation (Ctrl+Enter)"
+            >
+              Insert ↑
+            </button>
           </div>
 
           <p className="text-xs text-blue-400">Ctrl+Enter to insert · Esc to close</p>
@@ -200,6 +245,14 @@ const MixedMathEditor = ({
             <LaTeXRenderer text={value} />
           </div>
         </div>
+      )}
+
+      {/* Symbols modal (Greek, Chemistry, Vectors, etc.) */}
+      {showSymbols && (
+        <MathKeyboard
+          onInsert={insertSymbol}
+          onClose={() => setShowSymbols(false)}
+        />
       )}
     </div>
   );

--- a/src/components/MixedMathEditor.js
+++ b/src/components/MixedMathEditor.js
@@ -1,0 +1,208 @@
+import React, { useRef, useState, useEffect } from 'react';
+import 'mathlive';
+import LaTeXRenderer from './LaTeXRenderer';
+
+/**
+ * MixedMathEditor
+ * A textarea for prose combined with a MathLive WYSIWYG equation bar.
+ * Teachers type text normally; when they need a math expression they click
+ * "∑ Equation", type into the visual MathLive field (equations render live
+ * exactly like Desmos), then click "Insert" to drop it at cursor position.
+ * A KaTeX preview below shows the final rendered output.
+ */
+const MixedMathEditor = ({
+  value,
+  onChange,
+  placeholder,
+  rows = 4,
+  required = false,
+  'data-testid': testId,
+}) => {
+  const textareaRef = useRef(null);
+  const mathFieldRef = useRef(null);
+  const [showMathBar, setShowMathBar] = useState(false);
+  const [mathIsEmpty, setMathIsEmpty] = useState(true);
+  const [cursorPos, setCursorPos] = useState(null);
+
+  // Set up MathLive field whenever the bar opens
+  useEffect(() => {
+    if (!showMathBar) return;
+
+    let handler;
+
+    const setup = () => {
+      const mf = mathFieldRef.current;
+      if (!mf) return;
+      // Disable bottom-of-screen virtual keyboard
+      mf.mathVirtualKeyboardPolicy = 'manual';
+      // Reset on open
+      mf.value = '';
+      setMathIsEmpty(true);
+
+      handler = () => setMathIsEmpty(!mf.value || mf.value.trim() === '');
+      mf.addEventListener('input', handler);
+
+      setTimeout(() => { try { mf.focus(); } catch (_) {} }, 60);
+    };
+
+    if (customElements.get('math-field')) {
+      setup();
+    } else {
+      const t = setTimeout(setup, 120);
+      return () => clearTimeout(t);
+    }
+
+    return () => {
+      const mf = mathFieldRef.current;
+      if (mf && handler) mf.removeEventListener('input', handler);
+    };
+  }, [showMathBar]);
+
+  const saveCursor = () => {
+    if (textareaRef.current) setCursorPos(textareaRef.current.selectionStart);
+  };
+
+  const openMathBar = () => {
+    saveCursor();
+    setShowMathBar(true);
+  };
+
+  const closeMathBar = () => {
+    setShowMathBar(false);
+    textareaRef.current?.focus();
+  };
+
+  const insertEquation = () => {
+    const mf = mathFieldRef.current;
+    const latex = mf?.value?.trim() || '';
+    if (!latex) return;
+
+    const snippet = `$${latex}$ `;
+    const pos = cursorPos ?? (value || '').length;
+    const before = (value || '').slice(0, pos);
+    const after = (value || '').slice(pos);
+    // Add a space before the snippet only if the char before cursor isn't already a space
+    const sep = before.length > 0 && !before.endsWith(' ') ? ' ' : '';
+    const newValue = before + sep + snippet + after;
+    onChange(newValue);
+
+    setShowMathBar(false);
+
+    setTimeout(() => {
+      if (textareaRef.current) {
+        const newPos = pos + sep.length + snippet.length;
+        textareaRef.current.focus();
+        textareaRef.current.setSelectionRange(newPos, newPos);
+        setCursorPos(newPos);
+      }
+    }, 30);
+  };
+
+  const handleKeyDown = (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') insertEquation();
+    if (e.key === 'Escape') closeMathBar();
+  };
+
+  const hasPreview = value && value.includes('$');
+
+  return (
+    <div className="space-y-1.5">
+      {/* Textarea */}
+      <div className="relative">
+        <textarea
+          ref={textareaRef}
+          value={value || ''}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={saveCursor}
+          onKeyUp={saveCursor}
+          onClick={saveCursor}
+          placeholder={placeholder}
+          rows={rows}
+          required={required}
+          data-testid={testId}
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-y pr-28 text-sm"
+        />
+        <button
+          type="button"
+          onClick={openMathBar}
+          className={`absolute top-2 right-2 flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold transition-colors border ${
+            showMathBar
+              ? 'bg-blue-600 text-white border-blue-600'
+              : 'bg-white text-blue-600 border-blue-300 hover:bg-blue-50'
+          }`}
+        >
+          ∑ Equation
+        </button>
+      </div>
+
+      {/* Inline WYSIWYG math bar */}
+      {showMathBar && (
+        <div className="rounded-xl border-2 border-blue-400 bg-blue-50 p-3 space-y-2" onKeyDown={handleKeyDown}>
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-semibold text-blue-700">
+              Type your equation — it renders as you type
+            </span>
+            <span className="text-xs text-blue-500">
+              Try: <code className="bg-blue-100 px-1 rounded">x^2</code>&nbsp;
+              <code className="bg-blue-100 px-1 rounded">a//b</code>&nbsp;
+              <code className="bg-blue-100 px-1 rounded">sqrt</code>&nbsp;
+              <code className="bg-blue-100 px-1 rounded">pi</code>
+            </span>
+          </div>
+
+          {/* MathLive field */}
+          <div className="flex gap-2 items-stretch">
+            <div
+              className="flex-1 bg-white border border-blue-200 rounded-lg px-3 py-2 cursor-text flex items-center min-h-[52px]"
+              onClick={() => mathFieldRef.current?.focus()}
+            >
+              <math-field
+                ref={mathFieldRef}
+                style={{
+                  width: '100%',
+                  fontSize: '1.5rem',
+                  background: 'transparent',
+                  border: 'none',
+                  outline: 'none',
+                }}
+              />
+            </div>
+
+            <div className="flex flex-col gap-1">
+              <button
+                type="button"
+                onClick={insertEquation}
+                disabled={mathIsEmpty}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap flex-1"
+                title="Ctrl+Enter"
+              >
+                Insert ↑
+              </button>
+              <button
+                type="button"
+                onClick={closeMathBar}
+                className="px-4 py-2 bg-white border border-gray-200 text-gray-500 rounded-lg text-sm hover:text-gray-800"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+
+          <p className="text-xs text-blue-400">Ctrl+Enter to insert · Esc to close</p>
+        </div>
+      )}
+
+      {/* Live rendered preview */}
+      {hasPreview && (
+        <div className="px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg">
+          <p className="text-xs text-gray-400 font-medium mb-1">Preview</p>
+          <div className="text-sm text-gray-900">
+            <LaTeXRenderer text={value} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MixedMathEditor;

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -162,14 +162,18 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
       return false;
     }
 
-    if (assessmentData.assessmentMode === 'SUMMATIVE_MULTI_QUESTION' && (assessmentData.questions.length < 3 || assessmentData.questions.length > 20)) {
-      showNotification('Summative mode requires 3-20 questions', 'error');
+    if (assessmentData.assessmentMode === 'SUMMATIVE_MULTI_QUESTION' && (assessmentData.questions.length < 5 || assessmentData.questions.length > 20)) {
+      showNotification('Summative mode requires 5-20 questions', 'error');
       return false;
     }
 
     for (const q of assessmentData.questions) {
       if (!q.questionBody.trim()) {
         showNotification(`Question ${q.questionNumber} is missing question text`, 'error');
+        return false;
+      }
+      if (q.questionType === 'LONG_RESPONSE' && (q.maxMarks < 6 || q.maxMarks > 15)) {
+        showNotification(`Question ${q.questionNumber} is a Long Response question and must be between 6 and 15 marks`, 'error');
         return false;
       }
     }

--- a/src/pages/QuestionsPage.js
+++ b/src/pages/QuestionsPage.js
@@ -2,8 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import AIQuestionGenerator from '../components/AIQuestionGenerator';
-import MathKeyboard from '../components/MathKeyboard';
-import LaTeXRenderer from '../components/LaTeXRenderer';
+import MixedMathEditor from '../components/MixedMathEditor';
 import QuestionBank from '../components/QuestionBank';
 import { API } from '@/config';
 import { handleApiError } from '@/lib/handle-error';
@@ -14,8 +13,6 @@ export const QuestionsPage = ({ user }) => {
   const [activeTab, setActiveTab] = useState('manual'); // manual, ai, bank
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState(null);
-  const [showMathKeyboard, setShowMathKeyboard] = useState(false);
-  const [activeField, setActiveField] = useState(null);
   const [formData, setFormData] = useState({
     subject: '',
     exam_type: '',
@@ -87,20 +84,6 @@ export const QuestionsPage = ({ user }) => {
       loadQuestions();
     } catch (error) {
       handleApiError(error, 'Failed to delete question');
-    }
-  };
-
-  const openMathKeyboard = (field) => {
-    setActiveField(field);
-    setShowMathKeyboard(true);
-  };
-
-  const insertMath = (latex) => {
-    if (activeField) {
-      setFormData(prev => ({
-        ...prev,
-        [activeField]: prev[activeField] + latex
-      }));
     }
   };
 
@@ -213,67 +196,36 @@ export const QuestionsPage = ({ user }) => {
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">Topic</label>
-                    <div className="flex gap-2">
-                      <input
-                        type="text"
-                        className="flex-1 px-3 py-2 border rounded-lg"
-                        value={formData.topic}
-                        onChange={(e) => setFormData({ ...formData, topic: e.target.value })}
-                        required
-                        data-testid="topic-input"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => openMathKeyboard('topic')}
-                        className="px-3 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg"
-                        title="Math Keyboard"
-                      >
-                        𝑓(𝑥)
-                      </button>
-                    </div>
+                    <MixedMathEditor
+                      value={formData.topic}
+                      onChange={(v) => setFormData({ ...formData, topic: v })}
+                      placeholder="e.g., Quadratic equations"
+                      rows={1}
+                      required
+                      data-testid="topic-input"
+                    />
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">Question Text</label>
-                    <div className="relative">
-                      <textarea
-                        className="w-full px-3 py-2 border rounded-lg"
-                        rows="4"
-                        value={formData.question_text}
-                        onChange={(e) => setFormData({ ...formData, question_text: e.target.value })}
-                        required
-                        data-testid="question-text-input"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => openMathKeyboard('question_text')}
-                        className="absolute top-2 right-2 px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded text-sm"
-                        title="Math Keyboard"
-                      >
-                        𝑓(𝑥)
-                      </button>
-                    </div>
+                    <MixedMathEditor
+                      value={formData.question_text}
+                      onChange={(v) => setFormData({ ...formData, question_text: v })}
+                      placeholder="Enter your question here..."
+                      rows={4}
+                      required
+                      data-testid="question-text-input"
+                    />
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">Mark Scheme</label>
-                    <div className="relative">
-                      <textarea
-                        className="w-full px-3 py-2 border rounded-lg"
-                        rows="6"
-                        value={formData.mark_scheme}
-                        onChange={(e) => setFormData({ ...formData, mark_scheme: e.target.value })}
-                        placeholder="Enter marking criteria"
-                        required
-                        data-testid="mark-scheme-input"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => openMathKeyboard('mark_scheme')}
-                        className="absolute top-2 right-2 px-3 py-1 bg-gray-100 hover:bg-gray-200 rounded text-sm"
-                        title="Math Keyboard"
-                      >
-                        𝑓(𝑥)
-                      </button>
-                    </div>
+                    <MixedMathEditor
+                      value={formData.mark_scheme}
+                      onChange={(v) => setFormData({ ...formData, mark_scheme: v })}
+                      placeholder="Enter marking criteria..."
+                      rows={5}
+                      required
+                      data-testid="mark-scheme-input"
+                    />
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-gray-700 mb-1">Max Marks</label>
@@ -302,7 +254,7 @@ export const QuestionsPage = ({ user }) => {
             {!showForm && (
               <div className="bg-white p-8 rounded-lg shadow text-center">
                 <p className="text-gray-600 mb-4">Click "New Question" to create a question manually with full control over content and formatting.</p>
-                <p className="text-sm text-gray-500">Math keyboard available for LaTeX support in all text fields.</p>
+                <p className="text-sm text-gray-500">Click "∑ Equation" in any field to insert visual equations — no LaTeX knowledge needed.</p>
               </div>
             )}
           </div>
@@ -324,13 +276,6 @@ export const QuestionsPage = ({ user }) => {
         )}
       </div>
 
-      {/* Math Keyboard Modal */}
-      {showMathKeyboard && (
-        <MathKeyboard
-          onInsert={insertMath}
-          onClose={() => setShowMathKeyboard(false)}
-        />
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Overview
- Replaced the old 𝑓(𝑥) button and LaTeX symbol picker with a proper visual equation editor — teachers type an equation and see it render in real time (similar to Desmos/GeoGebra), no LaTeX knowledge needed
- Added a separate Symbols button (αβ) for subjects like Chemistry and Physics that need Greek letters, chemical equations, vectors etc.
- Added a close button (✕) on the equation bar that properly dismisses the editor including the on-screen keyboard
- Long Response questions now default to 6 marks when selected, show a warning if set outside 6–15, and block saving until corrected
- Summative assessments show a validation error if fewer than 5 questions are added before saving

## Screenshots
Easy type: <img width="1246" height="860" alt="image" src="https://github.com/user-attachments/assets/0da426c5-f421-4142-a60f-c0a0bc89d23f" />

Keyboard: <img width="1234" height="853" alt="image" src="https://github.com/user-attachments/assets/d432dc7b-c3c1-4fdd-9b33-1fe9ee8389f1" />

Additional settings: <img width="450" height="599" alt="image" src="https://github.com/user-attachments/assets/b95d0d31-2424-4278-912c-93d2afe4f4cd" />

Long Response check: 
<img width="1008" height="762" alt="image" src="https://github.com/user-attachments/assets/529c65ac-f9f2-4785-91bc-7eac094e3c5c" />
