### PR TITLE
[261] Update front end elements from Classic to OCR Assessment

### DIFF
--- a/src/components/DiagramRenderer.js
+++ b/src/components/DiagramRenderer.js
@@ -1,0 +1,366 @@
+import React from 'react';
+
+// ── Venn Diagram ──────────────────────────────────────────────────────────────
+const VennSVG = ({ diagram }) => {
+  const { sets = [], regions = {} } = diagram;
+  const W = 280, H = 180, r = 65;
+  const cy = 115;
+  const cx1 = W / 2 - 32; // 108
+  const cx2 = W / 2 + 32; // 172
+  // Midpoints of A-only, intersection, B-only x-regions
+  const xA = W / 2 - r;   // 75
+  const xM = W / 2;        // 140
+  const xB = W / 2 + r;   // 205
+
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', maxWidth: W }}>
+      <circle cx={cx1} cy={cy} r={r} fill="rgba(59,130,246,0.18)" stroke="rgb(59,130,246)" strokeWidth="2" />
+      <circle cx={cx2} cy={cy} r={r} fill="rgba(239,68,68,0.18)" stroke="rgb(239,68,68)" strokeWidth="2" />
+      {sets[0] && (
+        <text x={cx1} y={cy - r - 10} textAnchor="middle" fontSize="13" fontWeight="700" fill="rgb(29,78,216)">
+          {sets[0]}
+        </text>
+      )}
+      {sets[1] && (
+        <text x={cx2} y={cy - r - 10} textAnchor="middle" fontSize="13" fontWeight="700" fill="rgb(185,28,28)">
+          {sets[1]}
+        </text>
+      )}
+      {regions.A_only != null && (
+        <text x={xA} y={cy + 7} textAnchor="middle" fontSize="22" fontWeight="700" fill="rgb(29,78,216)">
+          {regions.A_only}
+        </text>
+      )}
+      {regions.intersection != null && (
+        <text x={xM} y={cy + 7} textAnchor="middle" fontSize="22" fontWeight="700" fill="rgb(55,65,81)">
+          {regions.intersection}
+        </text>
+      )}
+      {regions.B_only != null && (
+        <text x={xB} y={cy + 7} textAnchor="middle" fontSize="22" fontWeight="700" fill="rgb(185,28,28)">
+          {regions.B_only}
+        </text>
+      )}
+    </svg>
+  );
+};
+
+// ── Bar Chart ─────────────────────────────────────────────────────────────────
+const BarChartSVG = ({ diagram }) => {
+  const { x_labels = [], values = [], title, y_label, x_label } = diagram;
+  if (!values.length) return null;
+
+  const W = 320, H = 220;
+  const padT = title ? 30 : 15;
+  const padB = x_label ? 52 : 38;
+  const padL = y_label ? 46 : 36;
+  const padR = 15;
+  const cW = W - padL - padR;
+  const cH = H - padT - padB;
+  const maxVal = Math.max(...values, 1);
+  const n = values.length;
+  const barW = Math.min(44, (cW / n) * 0.55);
+  const step = cW / n;
+
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', maxWidth: W }}>
+      {title && (
+        <text x={W / 2} y={18} textAnchor="middle" fontSize="12" fontWeight="600" fill="#374151">{title}</text>
+      )}
+      {/* Axes */}
+      <line x1={padL} y1={padT} x2={padL} y2={padT + cH} stroke="#9CA3AF" strokeWidth="1.5" />
+      <line x1={padL} y1={padT + cH} x2={padL + cW} y2={padT + cH} stroke="#9CA3AF" strokeWidth="1.5" />
+      {/* Axis tick labels */}
+      <text x={padL - 4} y={padT + cH + 1} textAnchor="end" fontSize="9" fill="#9CA3AF">0</text>
+      <text x={padL - 4} y={padT + 6} textAnchor="end" fontSize="9" fill="#9CA3AF">{maxVal}</text>
+      {/* Y-axis label */}
+      {y_label && (
+        <text transform={`translate(12, ${padT + cH / 2}) rotate(-90)`} textAnchor="middle" fontSize="10" fill="#6B7280">
+          {y_label}
+        </text>
+      )}
+      {/* X-axis label */}
+      {x_label && (
+        <text x={padL + cW / 2} y={H - 5} textAnchor="middle" fontSize="10" fill="#6B7280">{x_label}</text>
+      )}
+      {/* Bars */}
+      {values.map((val, i) => {
+        const barH = Math.max(2, (val / maxVal) * cH);
+        const x = padL + i * step + (step - barW) / 2;
+        const y = padT + cH - barH;
+        const lx = x + barW / 2;
+        const ly = padT + cH + (n > 5 ? 12 : 16);
+        return (
+          <g key={i}>
+            <rect x={x} y={y} width={barW} height={barH} fill="rgb(59,130,246)" rx="2" />
+            <text x={lx} y={Math.max(y - 3, padT + 10)} textAnchor="middle" fontSize="10" fill="#374151">{val}</text>
+            {n > 6 ? (
+              <text x={lx} y={ly} textAnchor="end" fontSize="9" fill="#6B7280" transform={`rotate(-38, ${lx}, ${ly})`}>
+                {x_labels[i] ?? ''}
+              </text>
+            ) : (
+              <text x={lx} y={ly} textAnchor="middle" fontSize="9" fill="#6B7280">{x_labels[i] ?? ''}</text>
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+};
+
+// ── Line Graph ────────────────────────────────────────────────────────────────
+const LineGraphSVG = ({ diagram }) => {
+  const { series = [], title, x_label, y_label } = diagram;
+  const allPts = series.flatMap(s => s.points || []);
+  if (!allPts.length) return null;
+
+  const W = 320, H = 220;
+  const padT = title ? 30 : 15;
+  const padB = x_label ? 50 : 36;
+  const padL = y_label ? 46 : 36;
+  const padR = 15;
+  const cW = W - padL - padR;
+  const cH = H - padT - padB;
+
+  const xs = allPts.map(p => Number(p.x));
+  const ys = allPts.map(p => Number(p.y));
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const rX = maxX - minX || 1, rY = maxY - minY || 1;
+  const sx = x => padL + ((x - minX) / rX) * cW;
+  const sy = y => padT + cH - ((y - minY) / rY) * cH;
+  const COLORS = ['rgb(59,130,246)', 'rgb(239,68,68)', 'rgb(16,185,129)', 'rgb(245,158,11)'];
+
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', maxWidth: W }}>
+      {title && (
+        <text x={W / 2} y={18} textAnchor="middle" fontSize="12" fontWeight="600" fill="#374151">{title}</text>
+      )}
+      {/* Axes */}
+      <line x1={padL} y1={padT} x2={padL} y2={padT + cH} stroke="#9CA3AF" strokeWidth="1.5" />
+      <line x1={padL} y1={padT + cH} x2={padL + cW} y2={padT + cH} stroke="#9CA3AF" strokeWidth="1.5" />
+      {/* Tick labels */}
+      <text x={padL - 4} y={padT + cH + 4} textAnchor="end" fontSize="9" fill="#9CA3AF">{minX}</text>
+      <text x={padL + cW} y={padT + cH + 10} textAnchor="middle" fontSize="9" fill="#9CA3AF">{maxX}</text>
+      <text x={padL - 4} y={padT + cH} textAnchor="end" fontSize="9" fill="#9CA3AF">{minY}</text>
+      <text x={padL - 4} y={padT + 6} textAnchor="end" fontSize="9" fill="#9CA3AF">{maxY}</text>
+      {/* Axis labels */}
+      {y_label && (
+        <text transform={`translate(12, ${padT + cH / 2}) rotate(-90)`} textAnchor="middle" fontSize="10" fill="#6B7280">
+          {y_label}
+        </text>
+      )}
+      {x_label && (
+        <text x={padL + cW / 2} y={H - 5} textAnchor="middle" fontSize="10" fill="#6B7280">{x_label}</text>
+      )}
+      {/* Series lines and dots */}
+      {series.map((s, si) => {
+        const pts = (s.points || []).slice().sort((a, b) => Number(a.x) - Number(b.x));
+        if (!pts.length) return null;
+        const color = COLORS[si % COLORS.length];
+        const d = pts.map((p, i) => `${i === 0 ? 'M' : 'L'} ${sx(p.x)} ${sy(p.y)}`).join(' ');
+        return (
+          <g key={si}>
+            <path d={d} fill="none" stroke={color} strokeWidth="2" />
+            {pts.map((p, i) => <circle key={i} cx={sx(p.x)} cy={sy(p.y)} r="3.5" fill={color} />)}
+          </g>
+        );
+      })}
+      {/* Series legend */}
+      {series.length > 1 && series.map((s, si) => (
+        <g key={`leg${si}`}>
+          <rect x={padL + si * 80} y={padT + cH + 20} width="10" height="10" fill={COLORS[si % COLORS.length]} rx="2" />
+          <text x={padL + si * 80 + 14} y={padT + cH + 29} fontSize="9" fill="#374151">{s.label}</text>
+        </g>
+      ))}
+    </svg>
+  );
+};
+
+// ── Geometry ──────────────────────────────────────────────────────────────────
+const GeometrySVG = ({ diagram }) => {
+  const { points = [], lines = [], measurements = [], description } = diagram;
+  if (!points.length) return null;
+
+  const W = 240, H = 210, pad = 38;
+  const xs = points.map(p => Number(p.x));
+  const ys = points.map(p => Number(p.y));
+  const minX = Math.min(...xs), maxX = Math.max(...xs);
+  const minY = Math.min(...ys), maxY = Math.max(...ys);
+  const rX = maxX - minX || 1, rY = maxY - minY || 1;
+  const scale = Math.min((W - 2 * pad) / rX, (H - 2 * pad) / rY);
+  const svgX = x => pad + (x - minX) * scale;
+  const svgY = y => H - pad - (y - minY) * scale;
+  const ptMap = Object.fromEntries(points.map(p => [p.label, p]));
+
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', maxWidth: W }}>
+      {description && (
+        <text x={W / 2} y={13} textAnchor="middle" fontSize="10" fill="#6B7280">{description}</text>
+      )}
+      {/* Lines */}
+      {lines.map((ln, i) => {
+        const a = ptMap[ln[0]], b = ptMap[ln[1]];
+        if (!a || !b) return null;
+        return (
+          <line key={i}
+            x1={svgX(a.x)} y1={svgY(a.y)}
+            x2={svgX(b.x)} y2={svgY(b.y)}
+            stroke="#1F2937" strokeWidth="2"
+          />
+        );
+      })}
+      {/* Measurement labels on line midpoints */}
+      {measurements.map((m, i) => {
+        const seg = Array.isArray(m.segment) ? m.segment : [];
+        const a = ptMap[seg[0]], b = ptMap[seg[1]];
+        if (!a || !b) return null;
+        const mx = (svgX(a.x) + svgX(b.x)) / 2;
+        const my = (svgY(a.y) + svgY(b.y)) / 2;
+        return <text key={i} x={mx + 5} y={my - 3} fontSize="10" fill="#6B7280">{m.value}</text>;
+      })}
+      {/* Points */}
+      {points.map((p, i) => (
+        <g key={i}>
+          <circle cx={svgX(p.x)} cy={svgY(p.y)} r="3.5" fill="#374151" />
+          <text x={svgX(p.x) + 7} y={svgY(p.y) - 5} fontSize="12" fontWeight="700" fill="#111827">{p.label}</text>
+        </g>
+      ))}
+    </svg>
+  );
+};
+
+// ── Number Line ───────────────────────────────────────────────────────────────
+const NumberLineSVG = ({ diagram }) => {
+  const { min = 0, max = 10, marked_values = [], intervals } = diagram;
+  const W = 300, H = 72, padX = 28, lineY = 38;
+  const lineW = W - 2 * padX;
+  const range = max - min || 1;
+  const toX = v => padX + ((v - min) / range) * lineW;
+
+  const ticks = [];
+  if (intervals && intervals > 0) {
+    for (let v = min; v <= max + intervals * 0.01; v += intervals) {
+      ticks.push(Math.round(v * 1000) / 1000);
+    }
+  } else {
+    ticks.push(min, (min + max) / 2, max);
+  }
+
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} style={{ width: '100%', maxWidth: W }}>
+      <line x1={padX} y1={lineY} x2={padX + lineW} y2={lineY} stroke="#374151" strokeWidth="2.5" />
+      {/* Arrowhead */}
+      <polygon
+        points={`${padX + lineW},${lineY} ${padX + lineW - 9},${lineY - 4} ${padX + lineW - 9},${lineY + 4}`}
+        fill="#374151"
+      />
+      {ticks.map((v, i) => (
+        <g key={i}>
+          <line x1={toX(v)} y1={lineY - 6} x2={toX(v)} y2={lineY + 6} stroke="#374151" strokeWidth="1.5" />
+          <text x={toX(v)} y={lineY + 20} textAnchor="middle" fontSize="11" fill="#374151">{v}</text>
+        </g>
+      ))}
+      {marked_values.map((v, i) => (
+        <g key={`m${i}`}>
+          <circle cx={toX(v)} cy={lineY} r="6" fill="rgb(239,68,68)" />
+          <text x={toX(v)} y={lineY - 12} textAnchor="middle" fontSize="11" fontWeight="700" fill="rgb(185,28,28)">{v}</text>
+        </g>
+      ))}
+    </svg>
+  );
+};
+
+// ── Table ─────────────────────────────────────────────────────────────────────
+const TableDisplay = ({ diagram }) => (
+  <div className="overflow-x-auto">
+    {diagram.caption && <p className="text-xs text-gray-500 mb-1 italic">{diagram.caption}</p>}
+    <table className="border-collapse border border-gray-400 text-sm">
+      {diagram.headers && diagram.headers.length > 0 && (
+        <thead>
+          <tr>
+            {diagram.headers.map((h, i) => (
+              <th key={i} className="border border-gray-400 bg-gray-100 px-3 py-1 font-medium text-left">{h}</th>
+            ))}
+          </tr>
+        </thead>
+      )}
+      <tbody>
+        {(diagram.rows || []).map((row, i) => (
+          <tr key={i} className={i % 2 === 0 ? '' : 'bg-gray-50'}>
+            {row.map((cell, j) => (
+              <td key={j} className="border border-gray-400 px-3 py-1">{cell}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+// ── Main Renderer ─────────────────────────────────────────────────────────────
+const DiagramRenderer = ({ diagram, className = '' }) => {
+  if (!diagram) return null;
+
+  const { type } = diagram;
+
+  const wrap = (children) => (
+    <div className={`my-3 ${className}`}>
+      {type !== 'table' && diagram.caption && (
+        <p className="text-xs text-gray-500 mb-1 italic">{diagram.caption}</p>
+      )}
+      {children}
+    </div>
+  );
+
+  switch (type) {
+    case 'image':
+      return wrap(
+        <img
+          src={diagram.content}
+          alt={diagram.caption || 'Diagram'}
+          className="max-w-full h-auto border rounded shadow-sm"
+        />
+      );
+    case 'venn_diagram':
+      return wrap(<VennSVG diagram={diagram} />);
+    case 'bar_chart':
+      return wrap(<BarChartSVG diagram={diagram} />);
+    case 'line_graph':
+      return wrap(<LineGraphSVG diagram={diagram} />);
+    case 'geometry':
+      if (diagram.points && diagram.points.length > 0) {
+        return wrap(<GeometrySVG diagram={diagram} />);
+      }
+      // No coordinate data — show description and measurements as text
+      return wrap(
+        <div className="bg-gray-50 border rounded-lg p-3 text-sm">
+          <p className="font-medium text-gray-700 mb-1">Geometry</p>
+          {diagram.description && <p className="text-gray-600 mb-1">{diagram.description}</p>}
+          {(diagram.measurements || []).map((m, i) => (
+            <p key={i} className="text-xs text-gray-500">
+              {Array.isArray(m.segment) ? m.segment.join('') : m.segment}: {m.value}
+            </p>
+          ))}
+          {(diagram.angles || []).map((a, i) => (
+            <p key={i} className="text-xs text-gray-500">
+              Angle at {a.at}: {a.degrees != null ? `${a.degrees}°` : 'unknown'}
+            </p>
+          ))}
+        </div>
+      );
+    case 'table':
+      return wrap(<TableDisplay diagram={diagram} />);
+    case 'number_line':
+      return wrap(<NumberLineSVG diagram={diagram} />);
+    default:
+      return wrap(
+        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-sm">
+          <p className="font-medium text-yellow-800">Diagram ({type})</p>
+          <p className="text-yellow-700 text-xs mt-1">Diagram data captured — visual rendering not yet supported for this type.</p>
+        </div>
+      );
+  }
+};
+
+export default DiagramRenderer;

--- a/src/components/EnhancedAssessmentBuilder/AssessmentModeSelector.js
+++ b/src/components/EnhancedAssessmentBuilder/AssessmentModeSelector.js
@@ -3,13 +3,13 @@ import React from 'react';
 const AssessmentModeSelector = ({ selectedMode, onModeChange }) => {
   const modes = [
     {
-      id: 'CLASSIC',
-      name: '📝 Classic Mode',
-      description: 'Single question assessment (backward compatible)',
-      duration: '30-60 min',
-      questions: '1 question',
-      icon: '📝',
-      color: 'bg-gray-100 border-gray-300 hover:bg-gray-200'
+      id: 'OCR_GENERATED_GCSE_PAST_PAPER',
+      name: 'GCSE Past Paper (OCR Generated)',
+      description: 'Upload a GCSE past paper PDF and AI extracts the questions automatically',
+      duration: '30-120 min',
+      questions: 'AI extracted',
+      icon: '📤',
+      color: 'bg-orange-50 border-orange-300 hover:bg-orange-100'
     },
     {
       id: 'FORMATIVE_SINGLE_LONG_RESPONSE',

--- a/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
+++ b/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
@@ -5,6 +5,7 @@ import StructuredQuestionBuilder from './StructuredQuestionBuilder';
 import StimulusUploader from './StimulusUploader';
 import AIBulkGenerator from './AIBulkGenerator';
 import MixedMathEditor from '../MixedMathEditor';
+import DiagramRenderer from '../DiagramRenderer';
 
 const LONG_RESPONSE_MIN_MARKS = 6;
 const LONG_RESPONSE_MAX_MARKS = 15;
@@ -150,14 +151,30 @@ const QuestionEditor = ({
 
             {question.questionType && (
               <>
-                {/* Stimulus Uploader (for GCSE Structured) */}
-                {question.questionType === 'STRUCTURED_WITH_PARTS' && assessmentId && (
+                {/* Stimulus Uploader (for GCSE Structured — manual upload) */}
+                {question.questionType === 'STRUCTURED_WITH_PARTS' && assessmentId && !question.stimulusBlock && (
                   <StimulusUploader
                     assessmentId={assessmentId}
                     questionNumber={question.questionNumber}
                     currentStimulus={question.stimulusBlock}
                     onStimulusUploaded={(stimulus) => updateQuestion('stimulusBlock', stimulus)}
                   />
+                )}
+
+                {/* OCR-extracted diagram preview (shown for all question types when present) */}
+                {question.stimulusBlock && (
+                  <div className="border border-gray-200 rounded-lg p-3 bg-gray-50">
+                    <div className="flex justify-between items-center mb-1">
+                      <span className="text-xs font-medium text-gray-600 uppercase tracking-wide">Extracted Diagram</span>
+                      <button
+                        onClick={() => updateQuestion('stimulusBlock', null)}
+                        className="text-xs text-red-600 hover:text-red-700"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                    <DiagramRenderer diagram={question.stimulusBlock} />
+                  </div>
                 )}
 
                 {/* Question Body */}

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -29,7 +29,8 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     stage: 'KS4',
     examBoard: 'AQA',
     tier: 'Higher',
-    durationMinutes: 45,
+    yearSeries: '',
+    durationMinutes: 90,
     instructions: '',
     shuffleQuestions: false,
     shuffleOptions: false,
@@ -39,6 +40,72 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   });
 
   const [showAIBulk, setShowAIBulk] = useState(false);
+  const [extracting, setExtracting] = useState(false);
+  const [extractError, setExtractError] = useState(null);
+  const [questionPaperFile, setQuestionPaperFile] = useState(null);
+  const [markSchemeFile, setMarkSchemeFile] = useState(null);
+  const [questionPaperError, setQuestionPaperError] = useState(null);
+  const [markSchemeError, setMarkSchemeError] = useState(null);
+
+  const OCR_GCSE_MODE = 'OCR_GENERATED_GCSE_PAST_PAPER';
+
+  const validatePdfFile = (file) => {
+    if (!file) return null;
+    const ext = file.name.split('.').pop().toLowerCase();
+    if (ext !== 'pdf') return `Only PDF files are accepted. Received: "${file.name}". Please re-upload as a PDF.`;
+    if (file.size > 50 * 1024 * 1024) return 'File exceeds 50 MB. Please upload a smaller PDF.';
+    return null;
+  };
+
+  const handleQuestionPaperChange = useCallback((e) => {
+    const file = e.target.files[0];
+    e.target.value = '';
+    if (!file) return;
+    const err = validatePdfFile(file);
+    if (err) { setQuestionPaperError(err); return; }
+    setQuestionPaperError(null);
+    setQuestionPaperFile(file);
+  }, []);
+
+  const handleMarkSchemeChange = useCallback((e) => {
+    const file = e.target.files[0];
+    e.target.value = '';
+    if (!file) return;
+    const err = validatePdfFile(file);
+    if (err) { setMarkSchemeError(err); return; }
+    setMarkSchemeError(null);
+    setMarkSchemeFile(file);
+  }, []);
+
+  const handleExtract = useCallback(async () => {
+    if (!questionPaperFile && !markSchemeFile) {
+      setExtractError('Please upload at least one PDF (question paper or mark scheme) before extracting.');
+      return;
+    }
+    setExtracting(true);
+    setExtractError(null);
+    const formData = new FormData();
+    if (questionPaperFile) formData.append('file', questionPaperFile);
+    if (markSchemeFile) formData.append('mark_scheme', markSchemeFile);
+    formData.append('subject', assessmentData.subject);
+    formData.append('exam_board', assessmentData.examBoard);
+    try {
+      const response = await axios.post(
+        `${API}/teacher/assessments/extract-past-paper`,
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } }
+      );
+      const questions = response.data.questions.map((q, i) => ({ ...q, questionNumber: i + 1 }));
+      setAssessmentData(prev => ({ ...prev, questions }));
+      showNotification(`Extracted ${questions.length} question${questions.length !== 1 ? 's' : ''} successfully`, 'success');
+    } catch (error) {
+      const msg = getApiErrorMessage(error, 'Failed to extract questions from the uploaded PDF');
+      setExtractError(msg);
+      showNotification(msg, 'error');
+    } finally {
+      setExtracting(false);
+    }
+  }, [questionPaperFile, markSchemeFile, assessmentData.subject, assessmentData.examBoard]);
 
   useEffect(() => {
     if (isEdit) {
@@ -299,7 +366,119 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
           </div>
         )}
 
-        {currentStep === 2 && (
+        {currentStep === 2 && assessmentData.assessmentMode === OCR_GCSE_MODE && (
+          <div className="bg-white rounded-lg shadow p-6 space-y-4">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900">Past Paper Details</h2>
+              <p className="text-sm text-gray-500 mt-1">Enter the metadata for this past paper session. Title and subject are required.</p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Assessment Title *</label>
+              <input
+                type="text"
+                value={assessmentData.title}
+                onChange={(e) => updateField('title', e.target.value)}
+                placeholder="e.g., AQA Mathematics Higher — June 2023 Paper 1"
+                className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 ${!assessmentData.title.trim() ? 'border-red-300' : ''}`}
+              />
+              {!assessmentData.title.trim() && <p className="mt-1 text-xs text-red-500">Title is required</p>}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Subject *</label>
+                <select
+                  value={assessmentData.subject}
+                  onChange={(e) => updateField('subject', e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+                >
+                  <option>Mathematics</option>
+                  <option>Physics</option>
+                  <option>Chemistry</option>
+                  <option>Biology</option>
+                  <option>Combined Science</option>
+                  <option>English Language</option>
+                  <option>English Literature</option>
+                  <option>History</option>
+                  <option>Geography</option>
+                  <option>Computer Science</option>
+                  <option>Business Studies</option>
+                  <option>Economics</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Exam Board / Source</label>
+                <select
+                  value={assessmentData.examBoard}
+                  onChange={(e) => updateField('examBoard', e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+                >
+                  <option>AQA</option>
+                  <option>Edexcel</option>
+                  <option>OCR</option>
+                  <option>WJEC</option>
+                  <option>CIE</option>
+                  <option>Other</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Tier <span className="text-gray-400 font-normal">(optional)</span></label>
+                <select
+                  value={assessmentData.tier}
+                  onChange={(e) => updateField('tier', e.target.value)}
+                  className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+                >
+                  <option>Higher</option>
+                  <option>Foundation</option>
+                  <option>Intermediate</option>
+                  <option>None</option>
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Year / Series <span className="text-gray-400 font-normal">(optional)</span></label>
+                <input
+                  type="text"
+                  value={assessmentData.yearSeries}
+                  onChange={(e) => updateField('yearSeries', e.target.value)}
+                  placeholder="e.g., June 2023 Paper 1"
+                  className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Duration (minutes) — 1 to 120</label>
+              <input
+                type="number"
+                min="1"
+                max="120"
+                value={assessmentData.durationMinutes}
+                onChange={(e) => updateField('durationMinutes', parseInt(e.target.value) || 90)}
+                className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+
+            <div className="flex justify-between pt-4 border-t">
+              <button onClick={() => setCurrentStep(1)} className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50">← Back</button>
+              <button
+                onClick={() => {
+                  if (!assessmentData.title.trim()) { showNotification('Assessment title is required', 'error'); return; }
+                  if (!assessmentData.subject) { showNotification('Subject is required', 'error'); return; }
+                  setCurrentStep(3);
+                }}
+                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              >
+                Next: Upload Papers →
+              </button>
+            </div>
+          </div>
+        )}
+
+        {currentStep === 2 && assessmentData.assessmentMode !== OCR_GCSE_MODE && (
           <div className="bg-white rounded-lg shadow p-6 space-y-4">
             <h2 className="text-xl font-semibold text-gray-900">Assessment Details</h2>
 
@@ -375,13 +554,11 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Duration (minutes) - Between 1 and 60
-              </label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Duration (minutes) — 1 to 120</label>
               <input
                 type="number"
                 min="1"
-                max="60"
+                max="120"
                 value={assessmentData.durationMinutes}
                 onChange={(e) => updateField('durationMinutes', parseInt(e.target.value) || 45)}
                 className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
@@ -422,16 +599,8 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
             </div>
 
             <div className="flex justify-between pt-4 border-t">
-              <button
-                onClick={() => setCurrentStep(1)}
-                className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
-              >
-                ← Back
-              </button>
-              <button
-                onClick={() => setCurrentStep(3)}
-                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-              >
+              <button onClick={() => setCurrentStep(1)} className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50">← Back</button>
+              <button onClick={() => setCurrentStep(3)} className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
                 Next: Add Questions →
               </button>
             </div>
@@ -460,6 +629,103 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               </div>
             </div>
 
+            {assessmentData.assessmentMode === OCR_GCSE_MODE && (
+              <div className="bg-white rounded-lg shadow p-6 space-y-5">
+                <div>
+                  <h3 className="text-lg font-semibold text-gray-900">Upload Exam Documents</h3>
+                  <p className="text-sm text-gray-500 mt-1">
+                    Upload the question paper to extract questions automatically. Adding the mark scheme enables AI to pre-fill mark schemes for each question. PDF files only.
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {/* Question Paper */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Question Paper PDF <span className="text-gray-400 font-normal">(primary)</span></label>
+                    <label className={`flex flex-col items-center justify-center w-full py-6 border-2 border-dashed rounded-lg transition-colors ${
+                      extracting ? 'cursor-not-allowed opacity-60' :
+                      questionPaperFile ? 'border-green-400 bg-green-50 hover:bg-green-100 cursor-pointer' :
+                      'border-orange-300 bg-orange-50 hover:border-orange-400 hover:bg-orange-100 cursor-pointer'
+                    }`}>
+                      <span className="text-3xl mb-1">{questionPaperFile ? '✅' : '📄'}</span>
+                      <span className="font-medium text-sm text-gray-800 text-center px-2">
+                        {questionPaperFile ? questionPaperFile.name : 'Click to upload question paper'}
+                      </span>
+                      <span className="text-xs text-gray-500 mt-1">PDF only — up to 50 MB</span>
+                      <input type="file" accept=".pdf" className="hidden" disabled={extracting} onChange={handleQuestionPaperChange} />
+                    </label>
+                    {questionPaperError && (
+                      <p className="mt-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">{questionPaperError}</p>
+                    )}
+                    {questionPaperFile && !extracting && (
+                      <button onClick={() => setQuestionPaperFile(null)} className="mt-1 text-xs text-gray-400 hover:text-red-500 underline">Remove</button>
+                    )}
+                  </div>
+
+                  {/* Mark Scheme */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-2">Mark Scheme PDF <span className="text-gray-400 font-normal">(optional — pre-fills mark schemes)</span></label>
+                    <label className={`flex flex-col items-center justify-center w-full py-6 border-2 border-dashed rounded-lg transition-colors ${
+                      extracting ? 'cursor-not-allowed opacity-60' :
+                      markSchemeFile ? 'border-green-400 bg-green-50 hover:bg-green-100 cursor-pointer' :
+                      'border-gray-300 bg-gray-50 hover:border-gray-400 hover:bg-gray-100 cursor-pointer'
+                    }`}>
+                      <span className="text-3xl mb-1">{markSchemeFile ? '✅' : '📋'}</span>
+                      <span className="font-medium text-sm text-gray-800 text-center px-2">
+                        {markSchemeFile ? markSchemeFile.name : 'Click to upload mark scheme'}
+                      </span>
+                      <span className="text-xs text-gray-500 mt-1">PDF only — enables mark scheme pre-fill</span>
+                      <input type="file" accept=".pdf" className="hidden" disabled={extracting} onChange={handleMarkSchemeChange} />
+                    </label>
+                    {markSchemeError && (
+                      <p className="mt-2 text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">{markSchemeError}</p>
+                    )}
+                    {markSchemeFile && !extracting && (
+                      <button onClick={() => setMarkSchemeFile(null)} className="mt-1 text-xs text-gray-400 hover:text-red-500 underline">Remove</button>
+                    )}
+                  </div>
+                </div>
+
+                {!questionPaperFile && markSchemeFile && (
+                  <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
+                    <p className="text-sm text-yellow-700">
+                      ⚠️ No question paper uploaded. AI will infer questions from the mark scheme only — question text will be placeholder text that you must fill in manually after extraction.
+                    </p>
+                  </div>
+                )}
+
+                <div className="flex items-center justify-between pt-2">
+                  <span className="text-sm text-gray-500">
+                    {questionPaperFile && markSchemeFile ? '✓ Question paper + mark scheme ready' :
+                     questionPaperFile ? '✓ Question paper ready' :
+                     markSchemeFile ? '⚠ Mark scheme only' : 'No files selected'}
+                  </span>
+                  <button
+                    onClick={handleExtract}
+                    disabled={extracting || (!questionPaperFile && !markSchemeFile)}
+                    className="px-6 py-2 bg-orange-600 text-white rounded-lg hover:bg-orange-700 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 font-medium"
+                  >
+                    {extracting ? (
+                      <>
+                        <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                        Extracting… (may take 30–90s)
+                      </>
+                    ) : (
+                      '🔍 Extract Questions'
+                    )}
+                  </button>
+                </div>
+
+                {extractError && (
+                  <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">{extractError}</p>
+                )}
+
+                {assessmentData.questions.length === 0 && !extracting && !questionPaperFile && !markSchemeFile && (
+                  <p className="text-sm text-gray-400 text-center">Upload at least one document above, then click Extract Questions to begin.</p>
+                )}
+              </div>
+            )}
+
             <div className="space-y-4">
               {assessmentData.questions.map((question, index) => (
                 <Suspense key={index} fallback={<div className="p-4 bg-white rounded-lg shadow text-center text-gray-500">Loading question...</div>}>
@@ -482,12 +748,14 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                 >
                   + Add Question Manually
                 </button>
-                <button
-                  onClick={() => setShowAIBulk(true)}
-                  className="flex-1 py-4 border-2 border-dashed border-purple-300 rounded-lg hover:border-purple-400 hover:bg-purple-50 text-purple-600 hover:text-purple-700 font-medium transition-colors"
-                >
-                  🤖 Generate Multiple Questions with AI
-                </button>
+                {assessmentData.assessmentMode !== OCR_GCSE_MODE && (
+                  <button
+                    onClick={() => setShowAIBulk(true)}
+                    className="flex-1 py-4 border-2 border-dashed border-purple-300 rounded-lg hover:border-purple-400 hover:bg-purple-50 text-purple-600 hover:text-purple-700 font-medium transition-colors"
+                  >
+                    🤖 Generate Multiple Questions with AI
+                  </button>
+                )}
               </div>
             </div>
 

--- a/src/pages/EnhancedAttemptPage.js
+++ b/src/pages/EnhancedAttemptPage.js
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import StudentMathInput from '../components/StudentMathInput';
 import LaTeXRenderer from '../components/LaTeXRenderer';
+import DiagramRenderer from '../components/DiagramRenderer';
 import EnhancedFeedbackView from '../components/EnhancedFeedbackView';
 import QuestionSidebar from '../components/QuestionSidebar';
 import SecurityOverlays from '../components/SecurityOverlays';
@@ -282,6 +283,10 @@ export const EnhancedAttemptPage = () => {
               <LaTeXRenderer text={currentQuestion.questionBody || ''} />
             </div>
 
+            {currentQuestion.stimulusBlock && (
+              <DiagramRenderer diagram={currentQuestion.stimulusBlock} className="mt-2" />
+            )}
+
             {/* Structured Question Parts */}
             {currentQuestion.questionType === 'STRUCTURED_WITH_PARTS' && currentQuestion.parts && currentQuestion.parts.length > 0 && (
               <div className="mt-6 space-y-6">
@@ -300,6 +305,9 @@ export const EnhancedAttemptPage = () => {
                           <div className="prose max-w-none">
                             <LaTeXRenderer text={part.partPrompt || ''} />
                           </div>
+                          {part.partStimulus && (
+                            <DiagramRenderer diagram={part.partStimulus} className="mt-2" />
+                          )}
                         </div>
                       </div>
                       <div className="mt-3">


### PR DESCRIPTION
Added:   
- GCSE Past Paper (OCR Generated) mode card in the assessment type selector, sitting where Classic mode was
  - Dedicated Step 2 for OCR mode — collects title (required), subject (required), exam board, tier, year/series, and duration; blocks progression if title or subject are missing
  - Two-file upload panel in Step 3 — separate drop zones for the question paper PDF and the mark scheme PDF, each with file-type validation and clear error messages
  - Status summary line showing what files are ready before extraction begins
  - Warning banner shown when only a mark scheme is uploaded (no question paper)
  - yearSeries field sent to the backend when the assessment is saved

Updated:
  - Duration input maximum raised to 120 minutes; label corrected to match
  - Mode card for OCR GCSE shows "30–120 min" duration range
  - Extract flow changed from auto-trigger on file select to an explicit Extract Questions button, so teachers can attach both files before processing starts
  - AI Bulk Generator button hidden when OCR GCSE mode is selected (questions come from the
  uploaded paper, not AI generation)

Removed:
  - Classic Mode card from the assessment type selector
  - Auto-upload behaviour (single-file, triggered immediately on file selection)

Tickets:
https://github.com/ediare21/Blueai_Emergent/issues/261
https://github.com/ediare21/Blueai_Emergent/issues/262
https://github.com/ediare21/Blueai_Emergent/issues/263