### PR TITLE
[265] added ocr confience and review stage

### DIFF
--- a/src/components/AssessmentCard.jsx
+++ b/src/components/AssessmentCard.jsx
@@ -31,13 +31,14 @@ export const StatusBadge = ({ status }) => {
 // ─── Type badge ───────────────────────────────────────────────────────────────
 
 const MODE_TO_TYPE = {
-  CLASSIC:                        { label: "Classic",       bg: "bg-slate-100",   text: "text-slate-600"  },
-  FORMATIVE_SINGLE_LONG_RESPONSE: { label: "Formative",     bg: "bg-sky-100",     text: "text-sky-700"    },
-  SUMMATIVE_MULTI_QUESTION:       { label: "Summative",     bg: "bg-indigo-100",  text: "text-indigo-700" },
-  EXAM_STRUCTURED_GCSE_STYLE:     { label: "GCSE Style",    bg: "bg-purple-100",  text: "text-purple-700" },
-  OCR_GENERATED:                  { label: "OCR Generated", bg: "bg-amber-100",   text: "text-amber-700"  },
-  AI_GENERATED:                   { label: "AI Generated",  bg: "bg-violet-100",  text: "text-violet-700" },
-  MANUAL:                         { label: "Manual",        bg: "bg-gray-100",    text: "text-gray-600"   },
+  CLASSIC:                           { label: "Classic",          bg: "bg-slate-100",   text: "text-slate-600"  },
+  FORMATIVE_SINGLE_LONG_RESPONSE:    { label: "Formative",        bg: "bg-sky-100",     text: "text-sky-700"    },
+  SUMMATIVE_MULTI_QUESTION:          { label: "Summative",        bg: "bg-indigo-100",  text: "text-indigo-700" },
+  EXAM_STRUCTURED_GCSE_STYLE:        { label: "GCSE Style",       bg: "bg-purple-100",  text: "text-purple-700" },
+  OCR_GENERATED_GCSE_PAST_PAPER:     { label: "GCSE Past Paper",  bg: "bg-amber-100",   text: "text-amber-700"  },
+  OCR_GENERATED:                     { label: "OCR Generated",    bg: "bg-amber-100",   text: "text-amber-700"  },
+  AI_GENERATED:                      { label: "AI Generated",     bg: "bg-violet-100",  text: "text-violet-700" },
+  MANUAL:                            { label: "Manual",           bg: "bg-gray-100",    text: "text-gray-600"   },
 };
 
 export const TypeBadge = ({ mode }) => {
@@ -267,7 +268,8 @@ export const AssessmentCard = ({
   const isPublished = a.status === "published";
   const isStarted = a.status === "started";
   const isClosed = a.status === "closed";
-  const canEdit = (isDraft || isPublished) && isEnhanced;
+  const isOcrLocked = a.assessmentMode === "OCR_GENERATED_GCSE_PAST_PAPER" && a.ocrConfirmed;
+  const canEdit = (isDraft || isPublished) && isEnhanced && !isOcrLocked;
   const canStart = isDraft || isPublished;
 
   const viewDetailRoute = isEnhanced ? onViewEnhanced : onViewSubmissions;

--- a/src/components/EnhancedAssessmentBuilder/DiagramCropModal.js
+++ b/src/components/EnhancedAssessmentBuilder/DiagramCropModal.js
@@ -1,0 +1,203 @@
+import React, { useRef, useState, useCallback, useEffect } from 'react';
+
+/**
+ * DiagramCropModal
+ *
+ * Lets the teacher draw a selection rectangle on a rendered page image and
+ * confirms a new base64 JPEG crop for the question's stimulusBlock.
+ *
+ * Props:
+ *   pageImage     – data URI of the page at ~900px wide
+ *   currentDiagram – existing stimulusBlock (or null) shown as reference
+ *   onConfirm(stimulusBlock) – called with the new {type, content, caption} object
+ *   onRemove()    – called when the teacher wants to discard the current diagram
+ *   onClose()     – called to cancel without changes
+ */
+const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onClose }) => {
+  const imgRef = useRef(null);
+  const containerRef = useRef(null);
+
+  // Selection in 0-1 fractions of the displayed image
+  const [selection, setSelection] = useState(null);
+  const [dragStart, setDragStart] = useState(null);
+  const [dragging, setDragging] = useState(false);
+  const [imgLoaded, setImgLoaded] = useState(false);
+
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const getRelPos = useCallback((e) => {
+    const rect = containerRef.current.getBoundingClientRect();
+    return {
+      x: Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)),
+      y: Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)),
+    };
+  }, []);
+
+  const handleMouseDown = useCallback((e) => {
+    e.preventDefault();
+    const pos = getRelPos(e);
+    setDragStart(pos);
+    setDragging(true);
+    setSelection(null);
+  }, [getRelPos]);
+
+  const handleMouseMove = useCallback((e) => {
+    if (!dragging || !dragStart) return;
+    const pos = getRelPos(e);
+    setSelection({
+      x: Math.min(dragStart.x, pos.x),
+      y: Math.min(dragStart.y, pos.y),
+      w: Math.abs(pos.x - dragStart.x),
+      h: Math.abs(pos.y - dragStart.y),
+    });
+  }, [dragging, dragStart, getRelPos]);
+
+  const handleMouseUp = useCallback(() => {
+    setDragging(false);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    if (!selection || selection.w < 0.01 || selection.h < 0.01) return;
+    const srcImg = imgRef.current;
+    if (!srcImg) return;
+
+    const sw = srcImg.naturalWidth;
+    const sh = srcImg.naturalHeight;
+
+    const cx = Math.round(selection.x * sw);
+    const cy = Math.round(selection.y * sh);
+    const cw = Math.max(1, Math.round(selection.w * sw));
+    const ch = Math.max(1, Math.round(selection.h * sh));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = cw;
+    canvas.height = ch;
+    const ctx = canvas.getContext('2d');
+    ctx.drawImage(srcImg, cx, cy, cw, ch, 0, 0, cw, ch);
+
+    const dataUri = canvas.toDataURL('image/jpeg', 0.92);
+    onConfirm({ type: 'image', content: dataUri, caption: 'Diagram' });
+  }, [selection, onConfirm]);
+
+  const hasValidSelection = selection && selection.w > 0.01 && selection.h > 0.01;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50 p-4"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white rounded-xl shadow-2xl flex flex-col w-full max-w-4xl"
+           style={{ maxHeight: '92vh' }}>
+
+        {/* Header */}
+        <div className="px-5 py-4 border-b flex items-center justify-between shrink-0">
+          <div>
+            <h3 className="font-semibold text-gray-900">Crop Diagram</h3>
+            <p className="text-xs text-gray-500 mt-0.5">
+              Click and drag on the page to select the diagram area, then click Apply.
+            </p>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">✕</button>
+        </div>
+
+        {/* Page image with crop overlay */}
+        <div className="flex-1 overflow-y-auto min-h-0 p-4">
+          {!imgLoaded && (
+            <div className="flex items-center justify-center h-48 text-gray-400 text-sm">
+              Loading page…
+            </div>
+          )}
+          <div
+            ref={containerRef}
+            className={`relative select-none ${imgLoaded ? '' : 'hidden'}`}
+            style={{ cursor: 'crosshair' }}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseUp}
+          >
+            <img
+              ref={imgRef}
+              src={pageImage}
+              alt="Page"
+              className="w-full block border border-gray-200 rounded"
+              draggable={false}
+              onLoad={() => setImgLoaded(true)}
+            />
+
+            {/* Selection rectangle */}
+            {selection && (
+              <div
+                className="absolute pointer-events-none"
+                style={{
+                  left: `${selection.x * 100}%`,
+                  top: `${selection.y * 100}%`,
+                  width: `${selection.w * 100}%`,
+                  height: `${selection.h * 100}%`,
+                  border: '2px solid #2563eb',
+                  background: 'rgba(37,99,235,0.10)',
+                  boxSizing: 'border-box',
+                }}
+              />
+            )}
+
+            {/* Dimming overlay outside selection */}
+            {selection && (
+              <>
+                <div className="absolute inset-0 bg-black bg-opacity-30 pointer-events-none"
+                     style={{ clipPath: `polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%, 0% 0%, ${selection.x * 100}% ${selection.y * 100}%, ${selection.x * 100}% ${(selection.y + selection.h) * 100}%, ${(selection.x + selection.w) * 100}% ${(selection.y + selection.h) * 100}%, ${(selection.x + selection.w) * 100}% ${selection.y * 100}%, ${selection.x * 100}% ${selection.y * 100}%)` }} />
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-4 border-t shrink-0 flex items-center gap-3">
+          {/* Current diagram preview */}
+          {currentDiagram?.content && (
+            <div className="flex items-center gap-2 mr-auto">
+              <span className="text-xs text-gray-500 shrink-0">Current:</span>
+              <img
+                src={currentDiagram.content}
+                alt="Current crop"
+                className="h-12 w-auto border border-gray-200 rounded object-contain"
+              />
+              {onRemove && (
+                <button
+                  onClick={onRemove}
+                  className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-2 py-1 hover:bg-red-50"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+          )}
+          {!currentDiagram?.content && onRemove && (
+            <div className="mr-auto" />
+          )}
+
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!hasValidSelection}
+            className="px-5 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            Apply Crop
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DiagramCropModal;

--- a/src/components/EnhancedAssessmentBuilder/DiagramCropModal.js
+++ b/src/components/EnhancedAssessmentBuilder/DiagramCropModal.js
@@ -1,33 +1,89 @@
 import React, { useRef, useState, useCallback, useEffect } from 'react';
 
+// ─── Resize handle definitions ────────────────────────────────────────────────
+// Each handle sits at a specific position on the selection border.
+// style values are applied inside the selection div (position:absolute).
+const HANDLES = [
+  { name: 'nw', style: { top: -5,    left: -5    }, cursor: 'nw-resize' },
+  { name: 'n',  style: { top: -5,    left: '50%', transform: 'translateX(-50%)' }, cursor: 'n-resize'  },
+  { name: 'ne', style: { top: -5,    right: -5   }, cursor: 'ne-resize' },
+  { name: 'e',  style: { top: '50%', right: -5,   transform: 'translateY(-50%)' }, cursor: 'e-resize'  },
+  { name: 'se', style: { bottom: -5, right: -5   }, cursor: 'se-resize' },
+  { name: 's',  style: { bottom: -5, left: '50%', transform: 'translateX(-50%)' }, cursor: 's-resize'  },
+  { name: 'sw', style: { bottom: -5, left: -5    }, cursor: 'sw-resize' },
+  { name: 'w',  style: { top: '50%', left: -5,    transform: 'translateY(-50%)' }, cursor: 'w-resize'  },
+];
+
+// ─── Geometry helpers ─────────────────────────────────────────────────────────
+
+function applyResize(startSel, startPos, currentPos, handle) {
+  const dx = currentPos.x - startPos.x;
+  const dy = currentPos.y - startPos.y;
+  let { x, y, w, h } = startSel;
+
+  switch (handle) {
+    case 'nw': x += dx; y += dy; w -= dx; h -= dy; break;
+    case 'n':            y += dy;           h -= dy; break;
+    case 'ne':      w += dx; y += dy; h -= dy; break;
+    case 'e':       w += dx;                        break;
+    case 'se':      w += dx;             h += dy; break;
+    case 's':                            h += dy; break;
+    case 'sw': x += dx; w -= dx;         h += dy; break;
+    case 'w':  x += dx; w -= dx;                  break;
+    default: break;
+  }
+
+  // Normalise negative w/h (dragged past opposite edge)
+  if (w < 0) { x += w; w = -w; }
+  if (h < 0) { y += h; h = -h; }
+
+  x = Math.max(0, x);
+  y = Math.max(0, y);
+  w = Math.max(0.005, Math.min(1 - x, w));
+  h = Math.max(0.005, Math.min(1 - y, h));
+
+  return { x, y, w, h };
+}
+
+function applyMove(startSel, startPos, currentPos) {
+  const x = Math.max(0, Math.min(1 - startSel.w, startSel.x + (currentPos.x - startPos.x)));
+  const y = Math.max(0, Math.min(1 - startSel.h, startSel.y + (currentPos.y - startPos.y)));
+  return { ...startSel, x, y };
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
 /**
  * DiagramCropModal
  *
- * Lets the teacher draw a selection rectangle on a rendered page image and
- * confirms a new base64 JPEG crop for the question's stimulusBlock.
- *
  * Props:
- *   pageImage     – data URI of the page at ~900px wide
- *   currentDiagram – existing stimulusBlock (or null) shown as reference
- *   onConfirm(stimulusBlock) – called with the new {type, content, caption} object
- *   onRemove()    – called when the teacher wants to discard the current diagram
- *   onClose()     – called to cancel without changes
+ *   pageImage      – data URI of the rendered page (~900px wide)
+ *   currentDiagram – existing stimulusBlock shown as reference (or null)
+ *   onConfirm(stimulusBlock) – new {type, content, caption}
+ *   onRemove()     – discard existing diagram
+ *   onClose()      – cancel without changes
  */
 const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onClose }) => {
   const imgRef = useRef(null);
   const containerRef = useRef(null);
-
-  // Selection in 0-1 fractions of the displayed image
   const [selection, setSelection] = useState(null);
-  const [dragStart, setDragStart] = useState(null);
-  const [dragging, setDragging] = useState(false);
   const [imgLoaded, setImgLoaded] = useState(false);
+
+  // Keep a ref to current selection for use inside event handlers without
+  // re-creating them on every render.
+  const selectionRef = useRef(null);
+  useEffect(() => { selectionRef.current = selection; }, [selection]);
+
+  // Refs track the active interaction without causing re-renders on every move.
+  const drawStartRef = useRef(null);   // {x,y} when starting a new draw
+  const dragStateRef = useRef(null);   // { type:'move'|'resize', handle?, startPos, startSel }
+  const activeRef = useRef(false);
 
   // Close on Escape
   useEffect(() => {
-    const handler = (e) => { if (e.key === 'Escape') onClose(); };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
   const getRelPos = useCallback((e) => {
@@ -38,51 +94,85 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
     };
   }, []);
 
-  const handleMouseDown = useCallback((e) => {
+  // Clicking on the background area (outside any existing selection) starts a new draw
+  const handleBgMouseDown = useCallback((e) => {
+    if (e.button !== 0) return;
     e.preventDefault();
     const pos = getRelPos(e);
-    setDragStart(pos);
-    setDragging(true);
+    drawStartRef.current = pos;
+    activeRef.current = true;
     setSelection(null);
   }, [getRelPos]);
 
-  const handleMouseMove = useCallback((e) => {
-    if (!dragging || !dragStart) return;
+  // Clicking on the selection interior starts a move
+  const handleMoveStart = useCallback((e) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
     const pos = getRelPos(e);
-    setSelection({
-      x: Math.min(dragStart.x, pos.x),
-      y: Math.min(dragStart.y, pos.y),
-      w: Math.abs(pos.x - dragStart.x),
-      h: Math.abs(pos.y - dragStart.y),
-    });
-  }, [dragging, dragStart, getRelPos]);
+    dragStateRef.current = { type: 'move', startPos: pos, startSel: selectionRef.current };
+    activeRef.current = true;
+  }, [getRelPos]);
+
+  // Clicking on a resize handle starts a resize
+  const handleResizeStart = useCallback((handleName, e) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    const pos = getRelPos(e);
+    dragStateRef.current = { type: 'resize', handle: handleName, startPos: pos, startSel: selectionRef.current };
+    activeRef.current = true;
+  }, [getRelPos]);
+
+  const handleMouseMove = useCallback((e) => {
+    if (!activeRef.current) return;
+    const pos = getRelPos(e);
+
+    if (drawStartRef.current) {
+      const s = drawStartRef.current;
+      setSelection({
+        x: Math.min(s.x, pos.x),
+        y: Math.min(s.y, pos.y),
+        w: Math.abs(pos.x - s.x),
+        h: Math.abs(pos.y - s.y),
+      });
+      return;
+    }
+
+    if (dragStateRef.current) {
+      const { type, handle, startPos, startSel } = dragStateRef.current;
+      setSelection(type === 'move'
+        ? applyMove(startSel, startPos, pos)
+        : applyResize(startSel, startPos, pos, handle)
+      );
+    }
+  }, [getRelPos]);
 
   const handleMouseUp = useCallback(() => {
-    setDragging(false);
+    drawStartRef.current = null;
+    dragStateRef.current = null;
+    activeRef.current = false;
   }, []);
 
   const handleConfirm = useCallback(() => {
-    if (!selection || selection.w < 0.01 || selection.h < 0.01) return;
-    const srcImg = imgRef.current;
-    if (!srcImg) return;
+    const sel = selectionRef.current;
+    if (!sel || sel.w < 0.01 || sel.h < 0.01) return;
+    const src = imgRef.current;
+    if (!src) return;
 
-    const sw = srcImg.naturalWidth;
-    const sh = srcImg.naturalHeight;
-
-    const cx = Math.round(selection.x * sw);
-    const cy = Math.round(selection.y * sh);
-    const cw = Math.max(1, Math.round(selection.w * sw));
-    const ch = Math.max(1, Math.round(selection.h * sh));
-
+    const sw = src.naturalWidth;
+    const sh = src.naturalHeight;
+    const cw = Math.max(1, Math.round(sel.w * sw));
+    const ch = Math.max(1, Math.round(sel.h * sh));
     const canvas = document.createElement('canvas');
     canvas.width = cw;
     canvas.height = ch;
-    const ctx = canvas.getContext('2d');
-    ctx.drawImage(srcImg, cx, cy, cw, ch, 0, 0, cw, ch);
-
-    const dataUri = canvas.toDataURL('image/jpeg', 0.92);
-    onConfirm({ type: 'image', content: dataUri, caption: 'Diagram' });
-  }, [selection, onConfirm]);
+    canvas.getContext('2d').drawImage(src,
+      Math.round(sel.x * sw), Math.round(sel.y * sh), cw, ch,
+      0, 0, cw, ch
+    );
+    onConfirm({ type: 'image', content: canvas.toDataURL('image/jpeg', 0.92), caption: 'Diagram' });
+  }, [onConfirm]);
 
   const hasValidSelection = selection && selection.w > 0.01 && selection.h > 0.01;
 
@@ -91,32 +181,30 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
       className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50 p-4"
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
-      <div className="bg-white rounded-xl shadow-2xl flex flex-col w-full max-w-4xl"
-           style={{ maxHeight: '92vh' }}>
+      <div className="bg-white rounded-xl shadow-2xl flex flex-col w-full max-w-4xl" style={{ maxHeight: '92vh' }}>
 
         {/* Header */}
         <div className="px-5 py-4 border-b flex items-center justify-between shrink-0">
           <div>
             <h3 className="font-semibold text-gray-900">Crop Diagram</h3>
             <p className="text-xs text-gray-500 mt-0.5">
-              Click and drag on the page to select the diagram area, then click Apply.
+              Drag on the page to draw a selection · then drag handles to resize or drag the box to move it
             </p>
           </div>
           <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">✕</button>
         </div>
 
-        {/* Page image with crop overlay */}
+        {/* Page image canvas */}
         <div className="flex-1 overflow-y-auto min-h-0 p-4">
           {!imgLoaded && (
-            <div className="flex items-center justify-center h-48 text-gray-400 text-sm">
-              Loading page…
-            </div>
+            <div className="flex items-center justify-center h-48 text-gray-400 text-sm">Loading page…</div>
           )}
+
           <div
             ref={containerRef}
-            className={`relative select-none ${imgLoaded ? '' : 'hidden'}`}
-            style={{ cursor: 'crosshair' }}
-            onMouseDown={handleMouseDown}
+            className={`relative rounded border border-gray-200 ${imgLoaded ? '' : 'hidden'}`}
+            style={{ cursor: 'crosshair', userSelect: 'none' }}
+            onMouseDown={handleBgMouseDown}
             onMouseMove={handleMouseMove}
             onMouseUp={handleMouseUp}
             onMouseLeave={handleMouseUp}
@@ -125,32 +213,59 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
               ref={imgRef}
               src={pageImage}
               alt="Page"
-              className="w-full block border border-gray-200 rounded"
+              className="w-full block"
               draggable={false}
               onLoad={() => setImgLoaded(true)}
             />
 
-            {/* Selection rectangle */}
-            {selection && (
-              <div
-                className="absolute pointer-events-none"
-                style={{
-                  left: `${selection.x * 100}%`,
-                  top: `${selection.y * 100}%`,
-                  width: `${selection.w * 100}%`,
-                  height: `${selection.h * 100}%`,
-                  border: '2px solid #2563eb',
-                  background: 'rgba(37,99,235,0.10)',
-                  boxSizing: 'border-box',
-                }}
-              />
-            )}
-
-            {/* Dimming overlay outside selection */}
             {selection && (
               <>
-                <div className="absolute inset-0 bg-black bg-opacity-30 pointer-events-none"
-                     style={{ clipPath: `polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%, 0% 0%, ${selection.x * 100}% ${selection.y * 100}%, ${selection.x * 100}% ${(selection.y + selection.h) * 100}%, ${(selection.x + selection.w) * 100}% ${(selection.y + selection.h) * 100}%, ${(selection.x + selection.w) * 100}% ${selection.y * 100}%, ${selection.x * 100}% ${selection.y * 100}%)` }} />
+                {/* Dimming overlays — 4 rects surrounding the selection */}
+                {/* Top */}
+                <div className="absolute inset-x-0 top-0 bg-black bg-opacity-40 pointer-events-none"
+                     style={{ height: `${selection.y * 100}%` }} />
+                {/* Bottom */}
+                <div className="absolute inset-x-0 bg-black bg-opacity-40 pointer-events-none"
+                     style={{ top: `${(selection.y + selection.h) * 100}%`, bottom: 0 }} />
+                {/* Left */}
+                <div className="absolute bg-black bg-opacity-40 pointer-events-none"
+                     style={{ top: `${selection.y * 100}%`, height: `${selection.h * 100}%`, left: 0, width: `${selection.x * 100}%` }} />
+                {/* Right */}
+                <div className="absolute bg-black bg-opacity-40 pointer-events-none"
+                     style={{ top: `${selection.y * 100}%`, height: `${selection.h * 100}%`, left: `${(selection.x + selection.w) * 100}%`, right: 0 }} />
+
+                {/* Selection box — draggable to move */}
+                <div
+                  style={{
+                    position: 'absolute',
+                    left:   `${selection.x * 100}%`,
+                    top:    `${selection.y * 100}%`,
+                    width:  `${selection.w * 100}%`,
+                    height: `${selection.h * 100}%`,
+                    border: '2px solid #2563eb',
+                    cursor: 'move',
+                    boxSizing: 'border-box',
+                  }}
+                  onMouseDown={handleMoveStart}
+                >
+                  {/* Resize handles */}
+                  {HANDLES.map((h) => (
+                    <div
+                      key={h.name}
+                      style={{
+                        position: 'absolute',
+                        width: 10,
+                        height: 10,
+                        background: 'white',
+                        border: '2px solid #2563eb',
+                        borderRadius: 2,
+                        cursor: h.cursor,
+                        ...h.style,
+                      }}
+                      onMouseDown={(e) => handleResizeStart(h.name, e)}
+                    />
+                  ))}
+                </div>
               </>
             )}
           </div>
@@ -158,33 +273,23 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
 
         {/* Footer */}
         <div className="px-5 py-4 border-t shrink-0 flex items-center gap-3">
-          {/* Current diagram preview */}
           {currentDiagram?.content && (
             <div className="flex items-center gap-2 mr-auto">
               <span className="text-xs text-gray-500 shrink-0">Current:</span>
-              <img
-                src={currentDiagram.content}
-                alt="Current crop"
-                className="h-12 w-auto border border-gray-200 rounded object-contain"
-              />
+              <img src={currentDiagram.content} alt="Current crop"
+                   className="h-12 w-auto border border-gray-200 rounded object-contain" />
               {onRemove && (
-                <button
-                  onClick={onRemove}
-                  className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-2 py-1 hover:bg-red-50"
-                >
+                <button onClick={onRemove}
+                        className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-2 py-1 hover:bg-red-50">
                   Remove
                 </button>
               )}
             </div>
           )}
-          {!currentDiagram?.content && onRemove && (
-            <div className="mr-auto" />
-          )}
+          {!currentDiagram?.content && <div className="mr-auto" />}
 
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50"
-          >
+          <button onClick={onClose}
+                  className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50">
             Cancel
           </button>
           <button

--- a/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
+++ b/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
@@ -11,9 +11,24 @@ const getConfidenceTier = (score) => {
   return 'low';
 };
 
-const ConfidenceBadge = ({ score }) => {
-  const tier = getConfidenceTier(score);
-  const pct = score !== null && score !== undefined ? Math.round(score * 100) : null;
+// A question with an unresolved missing-diagram flag is always "needs review",
+// regardless of how high its raw confidence score is.
+const getEffectiveTier = (question) => {
+  const tier = getConfidenceTier(question.extractionConfidence);
+  if (
+    tier === 'high' &&
+    (question.extractionFlags || []).includes('diagram_referenced_but_missing') &&
+    !question.stimulusBlock
+  ) {
+    return 'medium';
+  }
+  return tier;
+};
+
+const ConfidenceBadge = ({ question }) => {
+  const tier = getEffectiveTier(question);
+  const pct = question.extractionConfidence !== null && question.extractionConfidence !== undefined
+    ? Math.round(question.extractionConfidence * 100) : null;
 
   const styles = {
     high: 'bg-green-100 text-green-800 border-green-200',
@@ -22,17 +37,17 @@ const ConfidenceBadge = ({ score }) => {
     unknown: 'bg-gray-100 text-gray-600 border-gray-200',
   };
   const labels = {
-    high: `High (${pct}%)`,
-    medium: `Review (${pct}%)`,
-    low: `Low (${pct}%)`,
+    high:    `High (${pct}%)`,
+    medium:  `Review (${pct}%)`,
+    low:     `Low (${pct}%)`,
     unknown: 'Unscored',
   };
 
   return (
     <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border ${styles[tier]}`}>
-      {tier === 'high' && '✓ '}
+      {tier === 'high'   && '✓ '}
       {tier === 'medium' && '⚠ '}
-      {tier === 'low' && '⚡ '}
+      {tier === 'low'    && '⚡ '}
       {labels[tier]}
     </span>
   );
@@ -112,7 +127,7 @@ const QuestionInlineEditor = ({ question, onChange }) => {
 const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, pageImages }) => {
   const [expanded, setExpanded] = useState(false);
   const [cropModalOpen, setCropModalOpen] = useState(false);
-  const tier = getConfidenceTier(question.extractionConfidence);
+  const tier = getEffectiveTier(question);
   const flags = question.extractionFlags || [];
 
   const pageImage = pageImages && question.page_num
@@ -128,6 +143,15 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
     onChange(index, { ...question, stimulusBlock: null });
     setCropModalOpen(false);
   };
+
+  const handleSkipMissingDiagram = () => {
+    onChange(index, {
+      ...question,
+      extractionFlags: (question.extractionFlags || []).filter(f => f !== 'diagram_referenced_but_missing'),
+    });
+  };
+
+  const isMissingDiagram = flags.includes('diagram_referenced_but_missing') && !question.stimulusBlock;
 
   const borderColor = {
     high: 'border-l-green-400',
@@ -182,7 +206,7 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
 
           <div className="flex-1 min-w-0">
             <div className="flex flex-wrap items-center gap-2 mb-1">
-              <ConfidenceBadge score={question.extractionConfidence} />
+              <ConfidenceBadge question={question} />
               <span className="text-xs text-gray-500">
                 {question.maxMarks != null ? `${question.maxMarks} mark${question.maxMarks !== 1 ? 's' : ''}` : 'marks unset'}
               </span>
@@ -207,12 +231,14 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
 
             {flags.length > 0 && (
               <ul className="mt-1.5 space-y-0.5">
-                {flags.map((flag) => (
-                  <li key={flag} className="text-xs text-amber-700 flex items-center gap-1">
-                    <span>⚠</span>
-                    {FLAG_LABELS[flag] || flag}
-                  </li>
-                ))}
+                {flags
+                  .filter(f => f !== 'diagram_referenced_but_missing')
+                  .map((flag) => (
+                    <li key={flag} className="text-xs text-amber-700 flex items-center gap-1">
+                      <span>⚠</span>
+                      {FLAG_LABELS[flag] || flag}
+                    </li>
+                  ))}
               </ul>
             )}
           </div>
@@ -233,6 +259,34 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
             </button>
           </div>
         </div>
+
+        {/* Missing diagram action banner */}
+        {isMissingDiagram && (
+          <div className="mt-3 ml-10 flex items-center justify-between gap-3 px-3 py-2.5 bg-amber-50 border border-amber-200 rounded-lg">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-amber-500 shrink-0">⚠</span>
+              <span className="text-sm text-amber-800">
+                This question references a diagram that wasn't automatically extracted.
+              </span>
+            </div>
+            <div className="flex gap-2 shrink-0">
+              {pageImage && (
+                <button
+                  onClick={() => setCropModalOpen(true)}
+                  className="px-3 py-1.5 text-xs font-medium bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+                >
+                  Crop diagram
+                </button>
+              )}
+              <button
+                onClick={handleSkipMissingDiagram}
+                className="px-3 py-1.5 text-xs font-medium border border-gray-300 rounded-lg hover:bg-gray-50 text-gray-700"
+              >
+                Skip
+              </button>
+            </div>
+          </div>
+        )}
 
         {/* Diagram preview + crop controls */}
         {!expanded && (
@@ -392,15 +446,17 @@ const SourcePagesPanel = ({ thumbnails }) => {
  *   onConfirm(qs)      – called with (possibly edited) questions when teacher confirms
  *   onBack()           – called when teacher wants to go back and re-upload
  */
-const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, pageThumbnails, pageImages, onConfirm, onBack }) => {
+const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, pageImages, onConfirm, onBack }) => {
   const [questions, setQuestions] = useState(() =>
     (initialQuestions || []).map((q, i) => ({ ...q, questionNumber: i + 1 }))
   );
   const [filterTier, setFilterTier] = useState('all'); // 'all' | 'high' | 'medium' | 'low'
 
-  const summary = extractionSummary || {};
-  const lowCount = summary.low_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'low').length;
-  const medCount = summary.medium_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'medium').length;
+  // Always recompute from live question state so that resolving a missing diagram
+  // (via crop or Skip) immediately updates the summary counts and filter bar.
+  const highCount = questions.filter((q) => getEffectiveTier(q) === 'high').length;
+  const medCount  = questions.filter((q) => getEffectiveTier(q) === 'medium').length;
+  const lowCount  = questions.filter((q) => getEffectiveTier(q) === 'low').length;
   const needsReview = lowCount + medCount;
 
   const moveQuestion = useCallback((fromIdx, toIdx) => {
@@ -430,7 +486,7 @@ const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, p
 
   const filteredQuestions = filterTier === 'all'
     ? questions
-    : questions.filter((q) => getConfidenceTier(q.extractionConfidence) === filterTier);
+    : questions.filter((q) => getEffectiveTier(q) === filterTier);
 
   return (
     <div className="space-y-4">
@@ -458,7 +514,7 @@ const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, p
             <span className="text-gray-500">questions</span>
           </div>
           <div className="flex items-center gap-2 px-3 py-2 bg-green-50 rounded-lg border border-green-200 text-sm">
-            <span className="font-semibold text-green-800">{summary.high_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'high').length}</span>
+            <span className="font-semibold text-green-800">{highCount}</span>
             <span className="text-green-700">high confidence</span>
           </div>
           <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 rounded-lg border border-amber-200 text-sm">
@@ -498,11 +554,7 @@ const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, p
             {tier === 'all' ? 'All' : tier.charAt(0).toUpperCase() + tier.slice(1)}
             {tier !== 'all' && (
               <span className="ml-1 opacity-70">
-                ({tier === 'high'
-                  ? (summary.high_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'high').length)
-                  : tier === 'medium'
-                  ? medCount
-                  : lowCount})
+                ({tier === 'high' ? highCount : tier === 'medium' ? medCount : lowCount})
               </span>
             )}
           </button>

--- a/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
+++ b/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
@@ -1,0 +1,480 @@
+import React, { useState, useCallback } from 'react';
+import DiagramRenderer from '../DiagramRenderer';
+
+// ─── Confidence helpers ───────────────────────────────────────────────────────
+
+const getConfidenceTier = (score) => {
+  if (score === null || score === undefined) return 'unknown';
+  if (score >= 0.80) return 'high';
+  if (score >= 0.60) return 'medium';
+  return 'low';
+};
+
+const ConfidenceBadge = ({ score }) => {
+  const tier = getConfidenceTier(score);
+  const pct = score !== null && score !== undefined ? Math.round(score * 100) : null;
+
+  const styles = {
+    high: 'bg-green-100 text-green-800 border-green-200',
+    medium: 'bg-amber-100 text-amber-800 border-amber-200',
+    low: 'bg-red-100 text-red-800 border-red-200',
+    unknown: 'bg-gray-100 text-gray-600 border-gray-200',
+  };
+  const labels = {
+    high: `High (${pct}%)`,
+    medium: `Review (${pct}%)`,
+    low: `Low (${pct}%)`,
+    unknown: 'Unscored',
+  };
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border ${styles[tier]}`}>
+      {tier === 'high' && '✓ '}
+      {tier === 'medium' && '⚠ '}
+      {tier === 'low' && '⚡ '}
+      {labels[tier]}
+    </span>
+  );
+};
+
+const FLAG_LABELS = {
+  marks_not_found: 'Marks not found — please set manually',
+  question_number_unclear: 'Question number unclear',
+  question_text_very_short: 'Question text is very short',
+  diagram_referenced_but_missing: 'Diagram referenced but not extracted',
+  scanned_page_fallback: 'Extracted via Vision (scanned page)',
+};
+
+// ─── Inline edit form for a single question ───────────────────────────────────
+
+const QuestionInlineEditor = ({ question, onChange }) => {
+  const handleField = (field, value) => onChange({ ...question, [field]: value });
+
+  return (
+    <div className="mt-3 space-y-3 border-t pt-3">
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">Question text</label>
+        <textarea
+          value={question.questionBody || question.question_text || ''}
+          onChange={(e) => handleField('questionBody', e.target.value)}
+          rows={3}
+          className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+        />
+      </div>
+
+      <div className="flex gap-3">
+        <div className="w-28">
+          <label className="block text-xs font-medium text-gray-600 mb-1">Max marks</label>
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={question.maxMarks ?? ''}
+            onChange={(e) => handleField('maxMarks', parseInt(e.target.value) || 0)}
+            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="flex-1">
+          <label className="block text-xs font-medium text-gray-600 mb-1">Question type</label>
+          <select
+            value={question.questionType || 'SHORT_ANSWER'}
+            onChange={(e) => handleField('questionType', e.target.value)}
+            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500"
+          >
+            <option value="SHORT_ANSWER">Short Answer</option>
+            <option value="NUMERIC">Numeric</option>
+            <option value="LONG_RESPONSE">Long Response</option>
+            <option value="MULTIPLE_CHOICE">Multiple Choice</option>
+            <option value="STRUCTURED_WITH_PARTS">Structured with Parts</option>
+          </select>
+        </div>
+      </div>
+
+      {question.markScheme && (
+        <div>
+          <label className="block text-xs font-medium text-gray-600 mb-1">Mark scheme (pre-filled from PDF)</label>
+          <textarea
+            value={question.markScheme}
+            onChange={(e) => handleField('markScheme', e.target.value)}
+            rows={2}
+            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 font-mono"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Single question card ─────────────────────────────────────────────────────
+
+const QuestionCard = ({ question, index, total, onMove, onChange, onRemove }) => {
+  const [expanded, setExpanded] = useState(false);
+  const tier = getConfidenceTier(question.extractionConfidence);
+  const flags = question.extractionFlags || [];
+
+  const borderColor = {
+    high: 'border-l-green-400',
+    medium: 'border-l-amber-400',
+    low: 'border-l-red-400',
+    unknown: 'border-l-gray-300',
+  }[tier];
+
+  const bodyText = (question.questionBody || question.question_text || '').trim();
+  const preview = bodyText.length > 100 ? bodyText.slice(0, 100) + '…' : bodyText;
+
+  const hasSubParts = question.questionType === 'STRUCTURED_WITH_PARTS' && question.parts?.length > 0;
+
+  return (
+    <div className={`bg-white rounded-lg border-l-4 border border-gray-200 ${borderColor} shadow-sm`}>
+      <div className="p-4">
+        <div className="flex items-start gap-3">
+          {/* Reorder buttons */}
+          <div className="flex flex-col gap-0.5 pt-0.5 shrink-0">
+            <button
+              onClick={() => onMove(index, index - 1)}
+              disabled={index === 0}
+              title="Move up"
+              className="p-0.5 rounded text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed"
+            >
+              ▲
+            </button>
+            <button
+              onClick={() => onMove(index, index + 1)}
+              disabled={index === total - 1}
+              title="Move down"
+              className="p-0.5 rounded text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed"
+            >
+              ▼
+            </button>
+          </div>
+
+          {/* Question number badge */}
+          <span className="shrink-0 inline-flex items-center justify-center w-7 h-7 rounded-full bg-blue-600 text-white text-xs font-bold mt-0.5">
+            {question.questionNumber}
+          </span>
+
+          <div className="flex-1 min-w-0">
+            <div className="flex flex-wrap items-center gap-2 mb-1">
+              <ConfidenceBadge score={question.extractionConfidence} />
+              <span className="text-xs text-gray-500">
+                {question.maxMarks != null ? `${question.maxMarks} mark${question.maxMarks !== 1 ? 's' : ''}` : 'marks unset'}
+              </span>
+              <span className="text-xs text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded">
+                {question.questionType || 'SHORT_ANSWER'}
+              </span>
+              {hasSubParts && (
+                <span className="text-xs text-purple-600 bg-purple-50 px-1.5 py-0.5 rounded">
+                  {question.parts.length} sub-parts
+                </span>
+              )}
+              {question.stimulusBlock && (
+                <span className="text-xs text-blue-600 bg-blue-50 px-1.5 py-0.5 rounded">
+                  Has diagram
+                </span>
+              )}
+            </div>
+
+            <p className="text-sm text-gray-800 leading-snug">
+              {preview || <span className="italic text-gray-400">No question text extracted</span>}
+            </p>
+
+            {flags.length > 0 && (
+              <ul className="mt-1.5 space-y-0.5">
+                {flags.map((flag) => (
+                  <li key={flag} className="text-xs text-amber-700 flex items-center gap-1">
+                    <span>⚠</span>
+                    {FLAG_LABELS[flag] || flag}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="px-2 py-1 text-xs text-blue-600 hover:text-blue-800 border border-blue-200 rounded hover:bg-blue-50"
+            >
+              {expanded ? 'Collapse' : 'Edit'}
+            </button>
+            <button
+              onClick={() => onRemove(index)}
+              title="Remove question"
+              className="px-2 py-1 text-xs text-red-500 hover:text-red-700 border border-red-200 rounded hover:bg-red-50"
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        {/* Diagram preview */}
+        {!expanded && question.stimulusBlock && (
+          <div className="mt-2 ml-10 max-w-xs border border-gray-200 rounded overflow-hidden">
+            <DiagramRenderer diagram={question.stimulusBlock} />
+          </div>
+        )}
+
+        {/* Expanded inline editor */}
+        {expanded && (
+          <div className="ml-10">
+            {question.stimulusBlock && (
+              <div className="mt-2 mb-2 border border-gray-200 rounded overflow-hidden max-w-sm">
+                <p className="text-xs text-gray-500 px-2 pt-1">Extracted diagram</p>
+                <DiagramRenderer diagram={question.stimulusBlock} />
+              </div>
+            )}
+            <QuestionInlineEditor question={question} onChange={(updated) => onChange(index, updated)} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ─── Source pages panel (side-by-side reference) ──────────────────────────────
+
+const SourcePagesPanel = ({ thumbnails }) => {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState(null);
+  const entries = Object.entries(thumbnails || {}).sort(([a], [b]) => Number(a) - Number(b));
+
+  if (!entries.length) return null;
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-5 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors"
+      >
+        <span className="flex items-center gap-2">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/>
+          </svg>
+          View original pages ({entries.length} page{entries.length !== 1 ? 's' : ''})
+        </span>
+        <span className="text-gray-400">{open ? '▲' : '▼'}</span>
+      </button>
+
+      {open && (
+        <div className="border-t border-gray-100">
+          {/* Thumbnail strip */}
+          <div className="flex gap-2 p-3 overflow-x-auto bg-gray-50">
+            {entries.map(([pageNum, src]) => (
+              <button
+                key={pageNum}
+                onClick={() => setSelected(selected === pageNum ? null : pageNum)}
+                className={`flex-shrink-0 border-2 rounded overflow-hidden transition-colors ${
+                  selected === pageNum ? 'border-blue-500' : 'border-gray-200 hover:border-gray-400'
+                }`}
+                title={`Page ${pageNum}`}
+              >
+                <img src={src} alt={`Page ${pageNum}`} className="h-24 w-auto" />
+                <div className="text-center text-xs text-gray-500 py-0.5 bg-white">p.{pageNum}</div>
+              </button>
+            ))}
+          </div>
+
+          {/* Expanded view of selected page */}
+          {selected && thumbnails[selected] && (
+            <div className="p-4 border-t border-gray-100 bg-white">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-sm font-medium text-gray-700">Page {selected}</span>
+                <button
+                  onClick={() => setSelected(null)}
+                  className="text-xs text-gray-400 hover:text-gray-600"
+                >
+                  Close ✕
+                </button>
+              </div>
+              <img
+                src={thumbnails[selected]}
+                alt={`Page ${selected} full view`}
+                className="w-full border border-gray-200 rounded shadow-sm"
+                style={{ maxHeight: '70vh', objectFit: 'contain' }}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Main review component ────────────────────────────────────────────────────
+
+/**
+ * OCRExtractionReview
+ *
+ * Presents extracted questions with confidence badges for teacher review
+ * before the assessment is finalised. Prevents auto-confirmation.
+ *
+ * Props:
+ *   questions          – array of extracted question objects
+ *   extractionSummary  – { avg_confidence, high_confidence, medium_confidence, low_confidence }
+ *   pageThumbnails     – { "1": "data:image/jpeg;base64,...", "2": ... } — original page images
+ *   onConfirm(qs)      – called with (possibly edited) questions when teacher confirms
+ *   onBack()           – called when teacher wants to go back and re-upload
+ */
+const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, pageThumbnails, onConfirm, onBack }) => {
+  const [questions, setQuestions] = useState(() =>
+    (initialQuestions || []).map((q, i) => ({ ...q, questionNumber: i + 1 }))
+  );
+  const [filterTier, setFilterTier] = useState('all'); // 'all' | 'high' | 'medium' | 'low'
+
+  const summary = extractionSummary || {};
+  const lowCount = summary.low_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'low').length;
+  const medCount = summary.medium_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'medium').length;
+  const needsReview = lowCount + medCount;
+
+  const moveQuestion = useCallback((fromIdx, toIdx) => {
+    if (toIdx < 0 || toIdx >= questions.length) return;
+    setQuestions((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(fromIdx, 1);
+      next.splice(toIdx, 0, moved);
+      return next.map((q, i) => ({ ...q, questionNumber: i + 1 }));
+    });
+  }, [questions.length]);
+
+  const updateQuestion = useCallback((idx, updated) => {
+    setQuestions((prev) => {
+      const next = [...prev];
+      next[idx] = { ...updated, questionNumber: idx + 1 };
+      return next;
+    });
+  }, []);
+
+  const removeQuestion = useCallback((idx) => {
+    setQuestions((prev) => {
+      const next = prev.filter((_, i) => i !== idx);
+      return next.map((q, i) => ({ ...q, questionNumber: i + 1 }));
+    });
+  }, []);
+
+  const filteredQuestions = filterTier === 'all'
+    ? questions
+    : questions.filter((q) => getConfidenceTier(q.extractionConfidence) === filterTier);
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="bg-white rounded-lg shadow p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Review Extracted Questions</h3>
+            <p className="text-sm text-gray-500 mt-0.5">
+              Check every question before confirming. Low-confidence items need your attention.
+            </p>
+          </div>
+          <button
+            onClick={onBack}
+            className="shrink-0 px-3 py-1.5 text-sm border border-gray-300 rounded-lg hover:bg-gray-50"
+          >
+            ← Re-upload
+          </button>
+        </div>
+
+        {/* Summary pills */}
+        <div className="mt-4 flex flex-wrap gap-3">
+          <div className="flex items-center gap-2 px-3 py-2 bg-gray-50 rounded-lg border text-sm">
+            <span className="font-semibold text-gray-900">{questions.length}</span>
+            <span className="text-gray-500">questions</span>
+          </div>
+          <div className="flex items-center gap-2 px-3 py-2 bg-green-50 rounded-lg border border-green-200 text-sm">
+            <span className="font-semibold text-green-800">{summary.high_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'high').length}</span>
+            <span className="text-green-700">high confidence</span>
+          </div>
+          <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 rounded-lg border border-amber-200 text-sm">
+            <span className="font-semibold text-amber-800">{medCount}</span>
+            <span className="text-amber-700">need review</span>
+          </div>
+          {lowCount > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-red-50 rounded-lg border border-red-200 text-sm">
+              <span className="font-semibold text-red-800">{lowCount}</span>
+              <span className="text-red-700">low confidence</span>
+            </div>
+          )}
+        </div>
+
+        {needsReview > 0 && (
+          <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800">
+            ⚠ <strong>{needsReview} question{needsReview !== 1 ? 's' : ''}</strong> need your attention. Click <strong>Edit</strong> on each highlighted question to check and correct the extracted text.
+          </div>
+        )}
+      </div>
+
+      {/* Source pages side-by-side panel */}
+      <SourcePagesPanel thumbnails={pageThumbnails} />
+
+      {/* Filter bar */}
+      <div className="flex gap-2">
+        {['all', 'high', 'medium', 'low'].map((tier) => (
+          <button
+            key={tier}
+            onClick={() => setFilterTier(tier)}
+            className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
+              filterTier === tier
+                ? 'bg-blue-600 text-white border-blue-600'
+                : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
+            }`}
+          >
+            {tier === 'all' ? 'All' : tier.charAt(0).toUpperCase() + tier.slice(1)}
+            {tier !== 'all' && (
+              <span className="ml-1 opacity-70">
+                ({tier === 'high'
+                  ? (summary.high_confidence ?? questions.filter((q) => getConfidenceTier(q.extractionConfidence) === 'high').length)
+                  : tier === 'medium'
+                  ? medCount
+                  : lowCount})
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Question list */}
+      {filteredQuestions.length === 0 ? (
+        <div className="bg-white rounded-lg border p-8 text-center text-gray-500 text-sm">
+          No questions in this category.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {filteredQuestions.map((q) => {
+            const realIdx = questions.indexOf(q);
+            return (
+              <QuestionCard
+                key={q.id || q.questionNumber}
+                question={q}
+                index={realIdx}
+                total={questions.length}
+                onMove={moveQuestion}
+                onChange={updateQuestion}
+                onRemove={removeQuestion}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {/* Sticky confirm bar */}
+      <div className="sticky bottom-0 bg-white border-t shadow-lg rounded-b-lg px-5 py-4 flex items-center justify-between gap-4">
+        <div className="text-sm text-gray-600">
+          {questions.length} question{questions.length !== 1 ? 's' : ''} ready to edit
+          {needsReview > 0 && (
+            <span className="ml-2 text-amber-700">· {needsReview} still need review</span>
+          )}
+        </div>
+        <button
+          onClick={() => onConfirm(questions)}
+          disabled={questions.length === 0}
+          className="px-6 py-2.5 bg-green-600 text-white rounded-lg hover:bg-green-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+        >
+          Confirm &amp; Edit Questions →
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default OCRExtractionReview;

--- a/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
+++ b/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import DiagramRenderer from '../DiagramRenderer';
+import DiagramCropModal from './DiagramCropModal';
 
 // ─── Confidence helpers ───────────────────────────────────────────────────────
 
@@ -108,10 +109,25 @@ const QuestionInlineEditor = ({ question, onChange }) => {
 
 // ─── Single question card ─────────────────────────────────────────────────────
 
-const QuestionCard = ({ question, index, total, onMove, onChange, onRemove }) => {
+const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, pageImages }) => {
   const [expanded, setExpanded] = useState(false);
+  const [cropModalOpen, setCropModalOpen] = useState(false);
   const tier = getConfidenceTier(question.extractionConfidence);
   const flags = question.extractionFlags || [];
+
+  const pageImage = pageImages && question.page_num
+    ? pageImages[String(question.page_num)]
+    : null;
+
+  const handleCropConfirm = (newStimulus) => {
+    onChange(index, { ...question, stimulusBlock: newStimulus });
+    setCropModalOpen(false);
+  };
+
+  const handleRemoveDiagram = () => {
+    onChange(index, { ...question, stimulusBlock: null });
+    setCropModalOpen(false);
+  };
 
   const borderColor = {
     high: 'border-l-green-400',
@@ -126,6 +142,16 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove }) =>
   const hasSubParts = question.questionType === 'STRUCTURED_WITH_PARTS' && question.parts?.length > 0;
 
   return (
+    <>
+    {cropModalOpen && pageImage && (
+      <DiagramCropModal
+        pageImage={pageImage}
+        currentDiagram={question.stimulusBlock}
+        onConfirm={handleCropConfirm}
+        onRemove={question.stimulusBlock ? handleRemoveDiagram : null}
+        onClose={() => setCropModalOpen(false)}
+      />
+    )}
     <div className={`bg-white rounded-lg border-l-4 border border-gray-200 ${borderColor} shadow-sm`}>
       <div className="p-4">
         <div className="flex items-start gap-3">
@@ -208,10 +234,41 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove }) =>
           </div>
         </div>
 
-        {/* Diagram preview */}
-        {!expanded && question.stimulusBlock && (
-          <div className="mt-2 ml-10 max-w-xs border border-gray-200 rounded overflow-hidden">
-            <DiagramRenderer diagram={question.stimulusBlock} />
+        {/* Diagram preview + crop controls */}
+        {!expanded && (
+          <div className="mt-2 ml-10">
+            {question.stimulusBlock && (
+              <div className="max-w-xs border border-gray-200 rounded overflow-hidden mb-1">
+                <DiagramRenderer diagram={question.stimulusBlock} />
+              </div>
+            )}
+            {pageImage && (
+              <div className="flex gap-2 mt-1">
+                {question.stimulusBlock ? (
+                  <>
+                    <button
+                      onClick={() => setCropModalOpen(true)}
+                      className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 rounded px-2 py-0.5 hover:bg-blue-50"
+                    >
+                      ✂ Fix crop
+                    </button>
+                    <button
+                      onClick={handleRemoveDiagram}
+                      className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-2 py-0.5 hover:bg-red-50"
+                    >
+                      Remove diagram
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    onClick={() => setCropModalOpen(true)}
+                    className="text-xs text-gray-600 hover:text-gray-900 border border-gray-300 rounded px-2 py-0.5 hover:bg-gray-50"
+                  >
+                    + Add diagram crop
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         )}
 
@@ -219,9 +276,27 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove }) =>
         {expanded && (
           <div className="ml-10">
             {question.stimulusBlock && (
-              <div className="mt-2 mb-2 border border-gray-200 rounded overflow-hidden max-w-sm">
+              <div className="mt-2 mb-1 border border-gray-200 rounded overflow-hidden max-w-sm">
                 <p className="text-xs text-gray-500 px-2 pt-1">Extracted diagram</p>
                 <DiagramRenderer diagram={question.stimulusBlock} />
+              </div>
+            )}
+            {pageImage && (
+              <div className="flex gap-2 mb-3">
+                <button
+                  onClick={() => setCropModalOpen(true)}
+                  className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 rounded px-2 py-0.5 hover:bg-blue-50"
+                >
+                  ✂ {question.stimulusBlock ? 'Fix crop' : 'Add diagram crop'}
+                </button>
+                {question.stimulusBlock && (
+                  <button
+                    onClick={handleRemoveDiagram}
+                    className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-2 py-0.5 hover:bg-red-50"
+                  >
+                    Remove diagram
+                  </button>
+                )}
               </div>
             )}
             <QuestionInlineEditor question={question} onChange={(updated) => onChange(index, updated)} />
@@ -229,6 +304,7 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove }) =>
         )}
       </div>
     </div>
+    </>
   );
 };
 
@@ -316,7 +392,7 @@ const SourcePagesPanel = ({ thumbnails }) => {
  *   onConfirm(qs)      – called with (possibly edited) questions when teacher confirms
  *   onBack()           – called when teacher wants to go back and re-upload
  */
-const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, pageThumbnails, onConfirm, onBack }) => {
+const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, pageThumbnails, pageImages, onConfirm, onBack }) => {
   const [questions, setQuestions] = useState(() =>
     (initialQuestions || []).map((q, i) => ({ ...q, questionNumber: i + 1 }))
   );
@@ -451,6 +527,7 @@ const OCRExtractionReview = ({ questions: initialQuestions, extractionSummary, p
                 onMove={moveQuestion}
                 onChange={updateQuestion}
                 onRemove={removeQuestion}
+                pageImages={pageImages}
               />
             );
           })}

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -52,6 +52,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   const [ocrReviewState, setOcrReviewState] = useState('uploading');
   const [extractionSummary, setExtractionSummary] = useState(null);
   const [pageThumbnails, setPageThumbnails] = useState({});
+  const [pageImages, setPageImages] = useState({});
 
   const OCR_GCSE_MODE = 'OCR_GENERATED_GCSE_PAST_PAPER';
 
@@ -106,6 +107,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
       setAssessmentData(prev => ({ ...prev, questions }));
       setExtractionSummary(response.data.extraction_summary || null);
       setPageThumbnails(response.data.page_thumbnails || {});
+      setPageImages(response.data.page_images || {});
       setOcrReviewState('reviewing');
       showNotification(
         `${questions.length} question${questions.length !== 1 ? 's' : ''} extracted — please review before confirming`,
@@ -127,10 +129,10 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   }, []);
 
   const handleOcrReviewBack = useCallback(() => {
-    // Clear extracted questions and go back to upload step
     setAssessmentData(prev => ({ ...prev, questions: [] }));
     setExtractionSummary(null);
     setPageThumbnails({});
+    setPageImages({});
     setOcrReviewState('uploading');
   }, []);
 
@@ -800,6 +802,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                   questions={assessmentData.questions}
                   extractionSummary={extractionSummary}
                   pageThumbnails={pageThumbnails}
+                  pageImages={pageImages}
                   onConfirm={handleOcrReviewConfirm}
                   onBack={handleOcrReviewBack}
                 />

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -800,7 +800,6 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading review…</div>}>
                 <OCRExtractionReview
                   questions={assessmentData.questions}
-                  extractionSummary={extractionSummary}
                   pageThumbnails={pageThumbnails}
                   pageImages={pageImages}
                   onConfirm={handleOcrReviewConfirm}

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -8,6 +8,7 @@ import { useAsync } from '@/hooks/use-async';
 const AssessmentModeSelector = lazy(() => import('../components/EnhancedAssessmentBuilder/AssessmentModeSelector'));
 const QuestionEditor = lazy(() => import('../components/EnhancedAssessmentBuilder/QuestionEditor'));
 const AIBulkGenerator = lazy(() => import('../components/EnhancedAssessmentBuilder/AIBulkGenerator'));
+const OCRExtractionReview = lazy(() => import('../components/EnhancedAssessmentBuilder/OCRExtractionReview'));
 
 export const EnhancedAssessmentBuilderPage = ({ user }) => {
   const navigate = useNavigate();
@@ -46,6 +47,11 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   const [markSchemeFile, setMarkSchemeFile] = useState(null);
   const [questionPaperError, setQuestionPaperError] = useState(null);
   const [markSchemeError, setMarkSchemeError] = useState(null);
+
+  // OCR sub-flow state: 'uploading' → 'reviewing' → 'editing'
+  const [ocrReviewState, setOcrReviewState] = useState('uploading');
+  const [extractionSummary, setExtractionSummary] = useState(null);
+  const [pageThumbnails, setPageThumbnails] = useState({});
 
   const OCR_GCSE_MODE = 'OCR_GENERATED_GCSE_PAST_PAPER';
 
@@ -96,8 +102,15 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
         { headers: { 'Content-Type': 'multipart/form-data' } }
       );
       const questions = response.data.questions.map((q, i) => ({ ...q, questionNumber: i + 1 }));
+      // Store extracted questions in state but go to review — do NOT auto-advance to editing
       setAssessmentData(prev => ({ ...prev, questions }));
-      showNotification(`Extracted ${questions.length} question${questions.length !== 1 ? 's' : ''} successfully`, 'success');
+      setExtractionSummary(response.data.extraction_summary || null);
+      setPageThumbnails(response.data.page_thumbnails || {});
+      setOcrReviewState('reviewing');
+      showNotification(
+        `${questions.length} question${questions.length !== 1 ? 's' : ''} extracted — please review before confirming`,
+        'success'
+      );
     } catch (error) {
       const msg = getApiErrorMessage(error, 'Failed to extract questions from the uploaded PDF');
       setExtractError(msg);
@@ -106,6 +119,20 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
       setExtracting(false);
     }
   }, [questionPaperFile, markSchemeFile, assessmentData.subject, assessmentData.examBoard]);
+
+  const handleOcrReviewConfirm = useCallback((reviewedQuestions) => {
+    setAssessmentData(prev => ({ ...prev, questions: reviewedQuestions }));
+    setOcrReviewState('editing');
+    showNotification('Extraction confirmed. You can now edit individual questions in detail.', 'success');
+  }, []);
+
+  const handleOcrReviewBack = useCallback(() => {
+    // Clear extracted questions and go back to upload step
+    setAssessmentData(prev => ({ ...prev, questions: [] }));
+    setExtractionSummary(null);
+    setPageThumbnails({});
+    setOcrReviewState('uploading');
+  }, []);
 
   useEffect(() => {
     if (isEdit) {
@@ -127,6 +154,16 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
       if (assessment.status === 'started') {
         showNotification('This assessment is live and cannot be edited while students are taking it.', 'error');
         setTimeout(() => navigate('/teacher/assessments'), 2000);
+        return;
+      }
+
+      if (assessment.assessmentMode === OCR_GCSE_MODE && assessment.ocrConfirmed) {
+        // Locked OCR assessment — redirect to detail page with a message
+        showNotification(
+          'This GCSE Past Paper assessment is locked after review. To re-extract, use "Unlock for re-extraction" on the assessment detail page.',
+          'error'
+        );
+        setTimeout(() => navigate(`/teacher/assessments/${assessmentId}/enhanced`), 2500);
         return;
       }
 
@@ -234,12 +271,16 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
       return false;
     }
 
+    const isOcrMode = assessmentData.assessmentMode === OCR_GCSE_MODE;
+
     for (const q of assessmentData.questions) {
       if (!q.questionBody.trim()) {
         showNotification(`Question ${q.questionNumber} is missing question text`, 'error');
         return false;
       }
-      if (q.questionType === 'LONG_RESPONSE' && (q.maxMarks < 6 || q.maxMarks > 15)) {
+      // Skip mark-range enforcement for OCR-extracted questions — marks come directly from the
+      // mark scheme and may legitimately be outside the 6-15 range used for teacher-authored questions
+      if (!isOcrMode && q.questionType === 'LONG_RESPONSE' && (q.maxMarks < 6 || q.maxMarks > 15)) {
         showNotification(`Question ${q.questionNumber} is a Long Response question and must be between 6 and 15 marks`, 'error');
         return false;
       }
@@ -251,15 +292,21 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   const saveDraft = () => {
     if (!validateAssessment()) return;
 
+    const isOcrMode = assessmentData.assessmentMode === OCR_GCSE_MODE;
+
     runSave(
       async () => {
         if (isEdit) {
           await axios.put(`${API}/teacher/assessments/${assessmentId}/questions`, assessmentData.questions);
+          // For OCR assessments being re-saved after edits, ocrConfirmed stays as-is
           showNotification('Draft saved successfully!', 'success');
         } else {
-          const response = await axios.post(`${API}/teacher/assessments/enhanced`, assessmentData);
+          // Set ocrConfirmed=true for OCR mode so teacher has explicitly reviewed extraction
+          const payload = isOcrMode ? { ...assessmentData, ocrConfirmed: true } : assessmentData;
+          const response = await axios.post(`${API}/teacher/assessments/enhanced`, payload);
+          const newId = response.data.assessment.id;
           showNotification('Assessment created as draft!', 'success');
-          navigate(`/teacher/assessments/${response.data.assessment.id}/edit`);
+          navigate(`/teacher/assessments/${newId}/enhanced`);
         }
       },
       (error) => {
@@ -275,12 +322,15 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
 
   const confirmPublish = () => {
     setShowPublishConfirm(false);
+    const isOcrMode = assessmentData.assessmentMode === OCR_GCSE_MODE;
+
     runSave(
       async () => {
         let finalAssessmentId = assessmentId;
 
         if (!isEdit) {
-          const response = await axios.post(`${API}/teacher/assessments/enhanced`, assessmentData);
+          const payload = isOcrMode ? { ...assessmentData, ocrConfirmed: true } : assessmentData;
+          const response = await axios.post(`${API}/teacher/assessments/enhanced`, payload);
           finalAssessmentId = response.data.assessment.id;
         } else {
           await axios.put(`${API}/teacher/assessments/${assessmentId}/questions`, assessmentData.questions);
@@ -327,7 +377,13 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               <h1 className="text-2xl font-bold text-gray-900">
                 {isEdit ? 'Edit Assessment' : 'Create New Assessment'}
               </h1>
-              <p className="text-sm text-gray-600">Step {currentStep} of 3</p>
+              <p className="text-sm text-gray-600">
+                {assessmentData.assessmentMode === OCR_GCSE_MODE && currentStep === 3
+                  ? ocrReviewState === 'uploading' ? 'Step 3 of 4 — Upload'
+                    : ocrReviewState === 'reviewing' ? 'Step 4 of 4 — Review Extraction'
+                    : 'Step 4 of 4 — Edit Questions'
+                  : `Step ${currentStep} of 3`}
+              </p>
             </div>
             <button
               onClick={() => navigate('/teacher/assessments')}
@@ -338,9 +394,20 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
           </div>
 
           <div className="mt-4 flex gap-2">
-            <div className={`flex-1 h-1 rounded ${currentStep >= 1 ? 'bg-blue-600' : 'bg-gray-200'}`} />
-            <div className={`flex-1 h-1 rounded ${currentStep >= 2 ? 'bg-blue-600' : 'bg-gray-200'}`} />
-            <div className={`flex-1 h-1 rounded ${currentStep >= 3 ? 'bg-blue-600' : 'bg-gray-200'}`} />
+            {assessmentData.assessmentMode === OCR_GCSE_MODE ? (
+              <>
+                <div className={`flex-1 h-1 rounded ${currentStep >= 1 ? 'bg-blue-600' : 'bg-gray-200'}`} />
+                <div className={`flex-1 h-1 rounded ${currentStep >= 2 ? 'bg-blue-600' : 'bg-gray-200'}`} />
+                <div className={`flex-1 h-1 rounded ${currentStep >= 3 ? 'bg-blue-600' : 'bg-gray-200'}`} />
+                <div className={`flex-1 h-1 rounded ${ocrReviewState !== 'uploading' ? 'bg-blue-600' : 'bg-gray-200'}`} />
+              </>
+            ) : (
+              <>
+                <div className={`flex-1 h-1 rounded ${currentStep >= 1 ? 'bg-blue-600' : 'bg-gray-200'}`} />
+                <div className={`flex-1 h-1 rounded ${currentStep >= 2 ? 'bg-blue-600' : 'bg-gray-200'}`} />
+                <div className={`flex-1 h-1 rounded ${currentStep >= 3 ? 'bg-blue-600' : 'bg-gray-200'}`} />
+              </>
+            )}
           </div>
         </div>
       </div>
@@ -629,7 +696,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               </div>
             </div>
 
-            {assessmentData.assessmentMode === OCR_GCSE_MODE && (
+            {assessmentData.assessmentMode === OCR_GCSE_MODE && ocrReviewState === 'uploading' && (
               <div className="bg-white rounded-lg shadow p-6 space-y-5">
                 <div>
                   <h3 className="text-lg font-semibold text-gray-900">Upload Exam Documents</h3>
@@ -708,7 +775,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                     {extracting ? (
                       <>
                         <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                        Extracting… (may take 30–90s)
+                        Extracting… (may take 30–60s)
                       </>
                     ) : (
                       '🔍 Extract Questions'
@@ -720,10 +787,23 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                   <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">{extractError}</p>
                 )}
 
-                {assessmentData.questions.length === 0 && !extracting && !questionPaperFile && !markSchemeFile && (
+                {!extracting && !questionPaperFile && !markSchemeFile && (
                   <p className="text-sm text-gray-400 text-center">Upload at least one document above, then click Extract Questions to begin.</p>
                 )}
               </div>
+            )}
+
+            {/* ── OCR Review step ── */}
+            {assessmentData.assessmentMode === OCR_GCSE_MODE && ocrReviewState === 'reviewing' && (
+              <Suspense fallback={<div className="p-8 text-center text-gray-500">Loading review…</div>}>
+                <OCRExtractionReview
+                  questions={assessmentData.questions}
+                  extractionSummary={extractionSummary}
+                  pageThumbnails={pageThumbnails}
+                  onConfirm={handleOcrReviewConfirm}
+                  onBack={handleOcrReviewBack}
+                />
+              </Suspense>
             )}
 
             <div className="space-y-4">

--- a/src/pages/EnhancedAssessmentDetailPage.js
+++ b/src/pages/EnhancedAssessmentDetailPage.js
@@ -103,7 +103,23 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
 
   const { assessment, submissions, attempts_count } = data;
   const isFormative = assessment.assessmentMode === 'FORMATIVE_SINGLE_LONG_RESPONSE';
+  const isOcrLocked = assessment.assessmentMode === 'OCR_GENERATED_GCSE_PAST_PAPER' && assessment.ocrConfirmed;
   const unreleasedCount = submissions?.filter(s => s.status === 'marked' && !s.feedback_released).length || 0;
+
+  const handleUnlockOcr = async () => {
+    if (!window.confirm(
+      'Unlock this GCSE Past Paper assessment for re-extraction?\n\n' +
+      'This will allow you to re-upload and re-extract questions from the PDF. ' +
+      'Existing questions will remain until you re-extract. Continue?'
+    )) return;
+    try {
+      await axios.post(`${API}/teacher/assessments/${assessmentId}/unlock-ocr`);
+      showSuccess('Assessment unlocked. You can now re-upload and re-extract.');
+      loadData();
+    } catch (error) {
+      handleApiError(error, 'Failed to unlock assessment');
+    }
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -139,6 +155,28 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
               </div>
             </div>
           </div>
+
+          {/* OCR lock banner */}
+          {isOcrLocked && (
+            <div className="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-lg flex items-start justify-between gap-4">
+              <div className="flex items-start gap-2">
+                <span className="text-amber-600 mt-0.5">🔒</span>
+                <div>
+                  <p className="text-sm font-semibold text-amber-800">GCSE Past Paper — OCR Review Confirmed</p>
+                  <p className="text-xs text-amber-700 mt-0.5">
+                    This assessment is locked after teacher review. Questions and mark scheme are fixed.
+                    To re-extract from the original PDF, unlock it below.
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={handleUnlockOcr}
+                className="shrink-0 px-3 py-1.5 text-xs font-medium border border-amber-400 text-amber-700 rounded-lg hover:bg-amber-100 transition-colors"
+              >
+                Unlock for re-extraction
+              </button>
+            </div>
+          )}
 
           {/* Bulk Actions */}
           {unreleasedCount > 0 && (


### PR DESCRIPTION
Added:
- `DiagramCropModal` — a new crop interface where teachers draw a selection rectangle on the original page image; the selection has 8 resize handles (corners and edges) and can be dragged to reposition, so adjustments don't require redrawing from scratch
- Per-question "Fix crop", "Add diagram crop", and "Remove diagram" buttons on the review screen
- Amber action banner on any question where a diagram was referenced but not extracted, with a "Crop diagram" shortcut (opens the modal) and a "Skip" option to accept the question without one — the banner disappears once resolved
- `pageImages` state stored and passed through from the extraction response

Updated:
- Questions with an unresolved missing diagram are now counted as "Needs Review" regardless of their raw confidence score; resolving the issue (by cropping or skipping) immediately moves them to "High" and updates the summary counts and filter bar live
- Confidence badge and all filter/count logic now use an effective tier calculation rather than the raw score alone


<img width="1228" height="897" alt="image" src="https://github.com/user-attachments/assets/9cd66a10-8441-4344-8484-c12b2d355ca6" />
