### PR TITLE
[272] fixed frontend issues and combined questions

### DIFF
--- a/src/components/EnhancedAssessmentBuilder/DiagramCropModal.js
+++ b/src/components/EnhancedAssessmentBuilder/DiagramCropModal.js
@@ -1,8 +1,6 @@
 import React, { useRef, useState, useCallback, useEffect } from 'react';
 
 // ─── Resize handle definitions ────────────────────────────────────────────────
-// Each handle sits at a specific position on the selection border.
-// style values are applied inside the selection div (position:absolute).
 const HANDLES = [
   { name: 'nw', style: { top: -5,    left: -5    }, cursor: 'nw-resize' },
   { name: 'n',  style: { top: -5,    left: '50%', transform: 'translateX(-50%)' }, cursor: 'n-resize'  },
@@ -33,7 +31,6 @@ function applyResize(startSel, startPos, currentPos, handle) {
     default: break;
   }
 
-  // Normalise negative w/h (dragged past opposite edge)
   if (w < 0) { x += w; w = -w; }
   if (h < 0) { y += h; h = -h; }
 
@@ -63,96 +60,112 @@ function applyMove(startSel, startPos, currentPos) {
  *   onRemove()     – discard existing diagram
  *   onClose()      – cancel without changes
  */
+
+const ZOOM_LEVELS = [1, 1.5, 2, 2.5, 3];
+
 const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onClose }) => {
-  const imgRef = useRef(null);
+  const imgRef       = useRef(null);
   const containerRef = useRef(null);
   const [selection, setSelection] = useState(null);
-  const [imgLoaded, setImgLoaded] = useState(false);
+  const [imgLoaded,  setImgLoaded]  = useState(false);
+  const [zoom, setZoom] = useState(1);
 
-  // Keep a ref to current selection for use inside event handlers without
-  // re-creating them on every render.
-  const selectionRef = useRef(null);
+  // Refs so event handlers can read latest state without stale closures.
+  const selectionRef  = useRef(null);
+  const drawStartRef  = useRef(null);   // {x,y} origin when drawing a new rect
+  const dragStateRef  = useRef(null);   // { type, handle?, startPos, startSel }
+  const activeRef     = useRef(false);
+
   useEffect(() => { selectionRef.current = selection; }, [selection]);
 
-  // Refs track the active interaction without causing re-renders on every move.
-  const drawStartRef = useRef(null);   // {x,y} when starting a new draw
-  const dragStateRef = useRef(null);   // { type:'move'|'resize', handle?, startPos, startSel }
-  const activeRef = useRef(false);
-
-  // Close on Escape
+  // ── Close on Escape ──────────────────────────────────────────────────────────
   useEffect(() => {
     const onKey = (e) => { if (e.key === 'Escape') onClose(); };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
+  // ── Normalised position relative to the image container ─────────────────────
+  // getBoundingClientRect() accounts for scroll offset automatically, so this
+  // is correct whether the container is scrolled or not.
   const getRelPos = useCallback((e) => {
     const rect = containerRef.current.getBoundingClientRect();
     return {
-      x: Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width)),
-      y: Math.max(0, Math.min(1, (e.clientY - rect.top) / rect.height)),
+      x: Math.max(0, Math.min(1, (e.clientX - rect.left)  / rect.width)),
+      y: Math.max(0, Math.min(1, (e.clientY - rect.top)   / rect.height)),
     };
   }, []);
 
-  // Clicking on the background area (outside any existing selection) starts a new draw
+  // ── Window-level mousemove / mouseup ─────────────────────────────────────────
+  // Attached to window so that:
+  //  • dragging continues if the cursor drifts onto a scrollbar or outside the container
+  //  • scrolling the view does not cancel an active draw/resize/move
+  useEffect(() => {
+    const onMove = (e) => {
+      if (!activeRef.current || !containerRef.current) return;
+      const pos = getRelPos(e);
+
+      if (drawStartRef.current) {
+        const s = drawStartRef.current;
+        setSelection({
+          x: Math.min(s.x, pos.x),
+          y: Math.min(s.y, pos.y),
+          w: Math.abs(pos.x - s.x),
+          h: Math.abs(pos.y - s.y),
+        });
+        return;
+      }
+
+      if (dragStateRef.current) {
+        const { type, handle, startPos, startSel } = dragStateRef.current;
+        setSelection(type === 'move'
+          ? applyMove(startSel, startPos, pos)
+          : applyResize(startSel, startPos, pos, handle)
+        );
+      }
+    };
+
+    const onUp = () => {
+      drawStartRef.current = null;
+      dragStateRef.current = null;
+      activeRef.current    = false;
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup',   onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup',   onUp);
+    };
+  }, [getRelPos]);
+
+  // ── Container mousedown handlers ─────────────────────────────────────────────
+
   const handleBgMouseDown = useCallback((e) => {
     if (e.button !== 0) return;
     e.preventDefault();
-    const pos = getRelPos(e);
-    drawStartRef.current = pos;
-    activeRef.current = true;
+    drawStartRef.current = getRelPos(e);
+    activeRef.current    = true;
     setSelection(null);
   }, [getRelPos]);
 
-  // Clicking on the selection interior starts a move
   const handleMoveStart = useCallback((e) => {
     if (e.button !== 0) return;
     e.preventDefault();
     e.stopPropagation();
-    const pos = getRelPos(e);
-    dragStateRef.current = { type: 'move', startPos: pos, startSel: selectionRef.current };
-    activeRef.current = true;
+    dragStateRef.current = { type: 'move', startPos: getRelPos(e), startSel: selectionRef.current };
+    activeRef.current    = true;
   }, [getRelPos]);
 
-  // Clicking on a resize handle starts a resize
   const handleResizeStart = useCallback((handleName, e) => {
     if (e.button !== 0) return;
     e.preventDefault();
     e.stopPropagation();
-    const pos = getRelPos(e);
-    dragStateRef.current = { type: 'resize', handle: handleName, startPos: pos, startSel: selectionRef.current };
-    activeRef.current = true;
+    dragStateRef.current = { type: 'resize', handle: handleName, startPos: getRelPos(e), startSel: selectionRef.current };
+    activeRef.current    = true;
   }, [getRelPos]);
 
-  const handleMouseMove = useCallback((e) => {
-    if (!activeRef.current) return;
-    const pos = getRelPos(e);
-
-    if (drawStartRef.current) {
-      const s = drawStartRef.current;
-      setSelection({
-        x: Math.min(s.x, pos.x),
-        y: Math.min(s.y, pos.y),
-        w: Math.abs(pos.x - s.x),
-        h: Math.abs(pos.y - s.y),
-      });
-      return;
-    }
-
-    if (dragStateRef.current) {
-      const { type, handle, startPos, startSel } = dragStateRef.current;
-      setSelection(type === 'move'
-        ? applyMove(startSel, startPos, pos)
-        : applyResize(startSel, startPos, pos, handle)
-      );
-    }
-  }, [getRelPos]);
-
-  const handleMouseUp = useCallback(() => {
-    drawStartRef.current = null;
-    dragStateRef.current = null;
-    activeRef.current = false;
-  }, []);
+  // ── Confirm crop ─────────────────────────────────────────────────────────────
 
   const handleConfirm = useCallback(() => {
     const sel = selectionRef.current;
@@ -165,7 +178,7 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
     const cw = Math.max(1, Math.round(sel.w * sw));
     const ch = Math.max(1, Math.round(sel.h * sh));
     const canvas = document.createElement('canvas');
-    canvas.width = cw;
+    canvas.width  = cw;
     canvas.height = ch;
     canvas.getContext('2d').drawImage(src,
       Math.round(sel.x * sw), Math.round(sel.y * sh), cw, ch,
@@ -175,6 +188,7 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
   }, [onConfirm]);
 
   const hasValidSelection = selection && selection.w > 0.01 && selection.h > 0.01;
+  const isZoomed          = zoom > 1;
 
   return (
     <div
@@ -188,26 +202,64 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
           <div>
             <h3 className="font-semibold text-gray-900">Crop Diagram</h3>
             <p className="text-xs text-gray-500 mt-0.5">
-              Drag on the page to draw a selection · then drag handles to resize or drag the box to move it
+              Drag on the page to draw a selection · drag handles to resize · drag the box to move it
+              {isZoomed && ' · scroll to pan around the image'}
             </p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">✕</button>
+          <div className="flex items-center gap-3">
+            {/* Zoom controls */}
+            <div className="flex items-center gap-1 border border-gray-200 rounded-lg px-2 py-1">
+              <button
+                onClick={() => setZoom(z => { const i = ZOOM_LEVELS.indexOf(z); return i > 0 ? ZOOM_LEVELS[i - 1] : z; })}
+                disabled={zoom === ZOOM_LEVELS[0]}
+                className="w-6 h-6 flex items-center justify-center text-gray-600 hover:text-gray-900 disabled:opacity-30 disabled:cursor-not-allowed font-bold text-lg leading-none"
+                title="Zoom out"
+              >−</button>
+              <span className="text-xs text-gray-600 w-8 text-center select-none">{zoom}×</span>
+              <button
+                onClick={() => setZoom(z => { const i = ZOOM_LEVELS.indexOf(z); return i < ZOOM_LEVELS.length - 1 ? ZOOM_LEVELS[i + 1] : z; })}
+                disabled={zoom === ZOOM_LEVELS[ZOOM_LEVELS.length - 1]}
+                className="w-6 h-6 flex items-center justify-center text-gray-600 hover:text-gray-900 disabled:opacity-30 disabled:cursor-not-allowed font-bold text-lg leading-none"
+                title="Zoom in"
+              >+</button>
+            </div>
+            <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">✕</button>
+          </div>
         </div>
 
-        {/* Page image canvas */}
-        <div className="flex-1 overflow-y-auto min-h-0 p-4">
+        {/* Scroll hint bar — only shown when zoomed */}
+        {isZoomed && imgLoaded && (
+          <div className="px-5 py-1.5 bg-blue-50 border-b border-blue-100 shrink-0 flex items-center gap-2">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#3b82f6" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M5 9l-3 3 3 3M9 5l3-3 3 3M15 19l-3 3-3-3M19 9l3 3-3 3M2 12h20M12 2v20"/>
+            </svg>
+            <span className="text-xs text-blue-700">Scrollbars active — use them to pan, then draw your crop selection</span>
+          </div>
+        )}
+
+        {/* Page image + scrollable canvas */}
+        <div
+          className="flex-1 min-h-0 p-4"
+          style={{
+            overflowX: isZoomed ? 'scroll' : 'auto',
+            overflowY: isZoomed ? 'scroll' : 'auto',
+          }}
+        >
           {!imgLoaded && (
             <div className="flex items-center justify-center h-48 text-gray-400 text-sm">Loading page…</div>
           )}
 
+          {/* Image container — expands to zoom * 100% wide, triggering both scrollbars */}
           <div
             ref={containerRef}
             className={`relative rounded border border-gray-200 ${imgLoaded ? '' : 'hidden'}`}
-            style={{ cursor: 'crosshair', userSelect: 'none' }}
+            style={{
+              cursor: 'crosshair',
+              userSelect: 'none',
+              width: `${zoom * 100}%`,
+              minWidth: `${zoom * 100}%`,
+            }}
             onMouseDown={handleBgMouseDown}
-            onMouseMove={handleMouseMove}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
           >
             <img
               ref={imgRef}
@@ -220,21 +272,17 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
 
             {selection && (
               <>
-                {/* Dimming overlays — 4 rects surrounding the selection */}
-                {/* Top */}
+                {/* Dimming overlays */}
                 <div className="absolute inset-x-0 top-0 bg-black bg-opacity-40 pointer-events-none"
                      style={{ height: `${selection.y * 100}%` }} />
-                {/* Bottom */}
                 <div className="absolute inset-x-0 bg-black bg-opacity-40 pointer-events-none"
                      style={{ top: `${(selection.y + selection.h) * 100}%`, bottom: 0 }} />
-                {/* Left */}
                 <div className="absolute bg-black bg-opacity-40 pointer-events-none"
                      style={{ top: `${selection.y * 100}%`, height: `${selection.h * 100}%`, left: 0, width: `${selection.x * 100}%` }} />
-                {/* Right */}
                 <div className="absolute bg-black bg-opacity-40 pointer-events-none"
                      style={{ top: `${selection.y * 100}%`, height: `${selection.h * 100}%`, left: `${(selection.x + selection.w) * 100}%`, right: 0 }} />
 
-                {/* Selection box — draggable to move */}
+                {/* Selection box */}
                 <div
                   style={{
                     position: 'absolute',
@@ -248,14 +296,12 @@ const DiagramCropModal = ({ pageImage, currentDiagram, onConfirm, onRemove, onCl
                   }}
                   onMouseDown={handleMoveStart}
                 >
-                  {/* Resize handles */}
                   {HANDLES.map((h) => (
                     <div
                       key={h.name}
                       style={{
                         position: 'absolute',
-                        width: 10,
-                        height: 10,
+                        width: 10, height: 10,
                         background: 'white',
                         border: '2px solid #2563eb',
                         borderRadius: 2,

--- a/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
+++ b/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
@@ -63,59 +63,122 @@ const FLAG_LABELS = {
 
 // ─── Inline edit form for a single question ───────────────────────────────────
 
+const inputCls = "w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500";
+
 const QuestionInlineEditor = ({ question, onChange }) => {
   const handleField = (field, value) => onChange({ ...question, [field]: value });
+  const isStructured = question.questionType === 'STRUCTURED_WITH_PARTS';
+
+  const handlePartField = (partIdx, field, value) => {
+    const newParts = [...(question.parts || [])];
+    newParts[partIdx] = { ...newParts[partIdx], [field]: value };
+    onChange({ ...question, parts: newParts });
+  };
 
   return (
     <div className="mt-3 space-y-3 border-t pt-3">
+      {/* Root question text */}
       <div>
-        <label className="block text-xs font-medium text-gray-600 mb-1">Question text</label>
+        <label className="block text-xs font-medium text-gray-600 mb-1">
+          {isStructured ? 'Shared question stem' : 'Question text'}
+        </label>
         <textarea
           value={question.questionBody || question.question_text || ''}
           onChange={(e) => handleField('questionBody', e.target.value)}
           rows={3}
-          className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+          className={inputCls}
         />
       </div>
 
-      <div className="flex gap-3">
-        <div className="w-28">
-          <label className="block text-xs font-medium text-gray-600 mb-1">Max marks</label>
-          <input
-            type="number"
-            min="0"
-            max="100"
-            value={question.maxMarks ?? ''}
-            onChange={(e) => handleField('maxMarks', parseInt(e.target.value) || 0)}
-            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500"
-          />
-        </div>
+      {/* Non-structured: marks, type, mark scheme */}
+      {!isStructured && (
+        <>
+          <div className="flex gap-3">
+            <div className="w-28">
+              <label className="block text-xs font-medium text-gray-600 mb-1">Max marks</label>
+              <input
+                type="number" min="0" max="100"
+                value={question.maxMarks ?? ''}
+                onChange={(e) => handleField('maxMarks', parseInt(e.target.value) || 0)}
+                className={inputCls}
+              />
+            </div>
+            <div className="flex-1">
+              <label className="block text-xs font-medium text-gray-600 mb-1">Question type</label>
+              <select
+                value={question.questionType || 'SHORT_ANSWER'}
+                onChange={(e) => handleField('questionType', e.target.value)}
+                className={inputCls}
+              >
+                <option value="SHORT_ANSWER">Short Answer</option>
+                <option value="NUMERIC">Numeric</option>
+                <option value="LONG_RESPONSE">Long Response</option>
+                <option value="MULTIPLE_CHOICE">Multiple Choice</option>
+                <option value="STRUCTURED_WITH_PARTS">Structured with Parts</option>
+              </select>
+            </div>
+          </div>
+          {question.markScheme && (
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Mark scheme (pre-filled from PDF)</label>
+              <textarea
+                value={question.markScheme}
+                onChange={(e) => handleField('markScheme', e.target.value)}
+                rows={2}
+                className={`${inputCls} font-mono`}
+              />
+            </div>
+          )}
+        </>
+      )}
 
-        <div className="flex-1">
-          <label className="block text-xs font-medium text-gray-600 mb-1">Question type</label>
-          <select
-            value={question.questionType || 'SHORT_ANSWER'}
-            onChange={(e) => handleField('questionType', e.target.value)}
-            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500"
-          >
-            <option value="SHORT_ANSWER">Short Answer</option>
-            <option value="NUMERIC">Numeric</option>
-            <option value="LONG_RESPONSE">Long Response</option>
-            <option value="MULTIPLE_CHOICE">Multiple Choice</option>
-            <option value="STRUCTURED_WITH_PARTS">Structured with Parts</option>
-          </select>
-        </div>
-      </div>
-
-      {question.markScheme && (
-        <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">Mark scheme (pre-filled from PDF)</label>
-          <textarea
-            value={question.markScheme}
-            onChange={(e) => handleField('markScheme', e.target.value)}
-            rows={2}
-            className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 font-mono"
-          />
+      {/* Structured: sub-parts editor */}
+      {isStructured && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-gray-600">
+            Sub-parts ({(question.parts || []).length}) — total {question.maxMarks ?? 0} marks
+          </p>
+          {(question.parts || []).map((part, partIdx) => (
+            <div key={partIdx} className="border border-purple-200 rounded-lg p-3 bg-purple-50 space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-bold text-purple-700 bg-purple-200 px-2 py-0.5 rounded">
+                  Part {part.partLabel}
+                </span>
+                <span className="text-xs text-purple-600">{part.maxMarks ?? 0} mark{part.maxMarks !== 1 ? 's' : ''}</span>
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Part text</label>
+                <textarea
+                  value={part.partPrompt || ''}
+                  onChange={(e) => handlePartField(partIdx, 'partPrompt', e.target.value)}
+                  rows={2}
+                  className={inputCls}
+                />
+              </div>
+              <div className="flex gap-3">
+                <div className="w-24">
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Marks</label>
+                  <input
+                    type="number" min="0" max="100"
+                    value={part.maxMarks ?? ''}
+                    onChange={(e) => handlePartField(partIdx, 'maxMarks', parseInt(e.target.value) || 0)}
+                    className={inputCls}
+                  />
+                </div>
+              </div>
+              {part.markScheme && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Mark scheme</label>
+                  <textarea
+                    value={part.markScheme}
+                    onChange={(e) => handlePartField(partIdx, 'markScheme', e.target.value)}
+                    rows={2}
+                    className={`${inputCls} font-mono`}
+                  />
+                </div>
+              )}
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -42,6 +42,8 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
 
   const [showAIBulk, setShowAIBulk] = useState(false);
   const [extracting, setExtracting] = useState(false);
+  const [extractProgress, setExtractProgress] = useState(0);
+  const [extractStuck, setExtractStuck] = useState(false);
   const [extractError, setExtractError] = useState(null);
   const [questionPaperFile, setQuestionPaperFile] = useState(null);
   const [markSchemeFile, setMarkSchemeFile] = useState(null);
@@ -91,6 +93,14 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     }
     setExtracting(true);
     setExtractError(null);
+    setExtractProgress(0);
+
+    // Simulate progress: advances quickly at first then decelerates, asymptotically
+    // approaching 98% so the bar keeps moving even on slow extractions.
+    const progressInterval = setInterval(() => {
+      setExtractProgress(prev => Math.min(98, Math.round(prev + (98 - prev) * 0.04)));
+    }, 500);
+
     const formData = new FormData();
     if (questionPaperFile) formData.append('file', questionPaperFile);
     if (markSchemeFile) formData.append('mark_scheme', markSchemeFile);
@@ -102,8 +112,11 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
         formData,
         { headers: { 'Content-Type': 'multipart/form-data' } }
       );
+      clearInterval(progressInterval);
+      setExtractProgress(100);
+      // Let the user see 100% before the page transitions.
+      await new Promise(resolve => setTimeout(resolve, 600));
       const questions = response.data.questions.map((q, i) => ({ ...q, questionNumber: i + 1 }));
-      // Store extracted questions in state but go to review — do NOT auto-advance to editing
       setAssessmentData(prev => ({ ...prev, questions }));
       setExtractionSummary(response.data.extraction_summary || null);
       setPageThumbnails(response.data.page_thumbnails || {});
@@ -114,6 +127,8 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
         'success'
       );
     } catch (error) {
+      clearInterval(progressInterval);
+      setExtractProgress(0);
       const msg = getApiErrorMessage(error, 'Failed to extract questions from the uploaded PDF');
       setExtractError(msg);
       showNotification(msg, 'error');
@@ -135,6 +150,17 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     setPageImages({});
     setOcrReviewState('uploading');
   }, []);
+
+  // Show a "do not refresh" warning if extractProgress hasn't changed for 5 seconds.
+  // Re-runs every time extractProgress changes, resetting the timer each time.
+  useEffect(() => {
+    if (!extracting || extractProgress >= 100) {
+      setExtractStuck(false);
+      return;
+    }
+    const timer = setTimeout(() => setExtractStuck(true), 5000);
+    return () => clearTimeout(timer);
+  }, [extractProgress, extracting]);
 
   useEffect(() => {
     if (isEdit) {
@@ -777,13 +803,34 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                     {extracting ? (
                       <>
                         <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                        Extracting… (may take 30–60s)
+                        Extracting…
                       </>
                     ) : (
                       '🔍 Extract Questions'
                     )}
                   </button>
                 </div>
+
+                {extracting && (
+                  <div className="pt-1">
+                    <div className="flex justify-between text-xs text-gray-500 mb-1">
+                      <span>Extracting questions from PDF…</span>
+                      <span>{extractProgress}%</span>
+                    </div>
+                    <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+                      <div
+                        className="bg-orange-500 h-2 rounded-full transition-all duration-500 ease-out"
+                        style={{ width: `${extractProgress}%` }}
+                      />
+                    </div>
+                    {extractStuck && (
+                      <p className="mt-2 text-xs font-medium text-amber-700 flex items-center gap-1.5">
+                        <span>⚠</span>
+                        Large papers can take a while — do not refresh this page or your upload will be lost.
+                      </p>
+                    )}
+                  </div>
+                )}
 
                 {extractError && (
                   <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">{extractError}</p>
@@ -808,6 +855,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               </Suspense>
             )}
 
+            {(assessmentData.assessmentMode !== OCR_GCSE_MODE || ocrReviewState === 'editing') && (
             <div className="space-y-4">
               {assessmentData.questions.map((question, index) => (
                 <Suspense key={index} fallback={<div className="p-4 bg-white rounded-lg shadow text-center text-gray-500">Loading question...</div>}>
@@ -840,6 +888,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                 )}
               </div>
             </div>
+            )}
 
             {showAIBulk && (
               <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">


### PR DESCRIPTION
  Added                                                                                  
  - Zoom controls (− / +) in the diagram crop modal, stepping through 1×–3× with both scrollbars active
  when zoomed so teachers can pan before cropping
  - "Do not refresh" warning below the progress bar if the percentage hasn't changed for 5 seconds
  - Extraction progress bar replacing the static "may take 30–60s" text, showing a live percentage that
  moves throughout the request and briefly shows 100% before advancing to the review screen

  Updated
  - Sub-parts are now visible and editable in the OCR review screen — each part's text, marks, and mark
  scheme are shown inline when a structured question is expanded
  - Diagram crop drag no longer cancels when the cursor touches a scrollbar or drifts outside the image
  — mouse handlers moved to window level

  Removed
  - Duplicate question list during OCR review — the full question editor was rendering alongside the
  review panel, showing every question twice; it now only appears after the teacher confirms the
  extraction