### PR TITLE
[38] Added drawing ability for student responses and other bug fixes

### DIFF
--- a/src/components/AssessmentCard.jsx
+++ b/src/components/AssessmentCard.jsx
@@ -304,12 +304,12 @@ export const AssessmentCard = ({
 
   return (
     <div
-      className="bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden"
+      className="bg-white border border-gray-200 rounded-xl shadow-sm hover:shadow-md transition-shadow duration-200"
       data-testid={`assessment-card-${a.id}`}
     >
       {/* Status accent bar */}
       <div
-        className={`h-1 w-full ${
+        className={`h-1 w-full rounded-t-xl ${
           isStarted ? "bg-green-400" :
           isPublished ? "bg-blue-400" :
           isClosed ? "bg-gray-300" :

--- a/src/components/ClassesPage.js
+++ b/src/components/ClassesPage.js
@@ -257,10 +257,17 @@ export const ClassDetailPage = ({ user }) => {
   const [activeTab, setActiveTab] = useState('students');
   const [showAddStudentModal, setShowAddStudentModal] = useState(false);
   const [showEditClassModal, setShowEditClassModal] = useState(false);
+  const [showAssignModal, setShowAssignModal] = useState(false);
+  const [assignments, setAssignments] = useState([]);
+  const [assignmentsLoading, setAssignmentsLoading] = useState(false);
 
   useEffect(() => {
     loadClassData();
   }, [classId]);
+
+  useEffect(() => {
+    if (activeTab === 'assignments') loadAssignments();
+  }, [activeTab, classId]);
 
   const loadClassData = async () => {
     try {
@@ -269,6 +276,36 @@ export const ClassDetailPage = ({ user }) => {
     } catch (error) {
     }
     setLoading(false);
+  };
+
+  const loadAssignments = async () => {
+    setAssignmentsLoading(true);
+    try {
+      const response = await axios.get(`${API}/teacher/classes/${classId}/assignments`);
+      setAssignments(response.data.assignments || []);
+    } catch (error) {
+    }
+    setAssignmentsLoading(false);
+  };
+
+  const handleToggleAssignment = async (assignmentId, currentStatus) => {
+    try {
+      const action = currentStatus === 'open' ? 'close' : 'open';
+      await axios.post(`${API}/teacher/assignments/${assignmentId}/${action}`);
+      loadAssignments();
+    } catch (error) {
+      handleApiError(error, 'Failed to update assignment');
+    }
+  };
+
+  const handleDeleteAssignment = async (assignmentId) => {
+    if (!window.confirm('Remove this assignment? The join code will no longer be valid.')) return;
+    try {
+      await axios.delete(`${API}/teacher/assignments/${assignmentId}`);
+      loadAssignments();
+    } catch (error) {
+      handleApiError(error, 'Failed to delete assignment');
+    }
   };
 
   const handleDeleteClass = async () => {
@@ -381,10 +418,20 @@ export const ClassDetailPage = ({ user }) => {
             Assessments ({classData.assessments.length})
           </button>
           <button
+            onClick={() => setActiveTab('assignments')}
+            className={`px-6 py-3 font-medium border-b-2 transition-colors ${
+              activeTab === 'assignments'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            Assignments
+          </button>
+          <button
             onClick={() => setActiveTab('analytics')}
             className={`px-6 py-3 font-medium border-b-2 transition-colors ${
-              activeTab === 'analytics' 
-                ? 'border-blue-600 text-blue-600' 
+              activeTab === 'analytics'
+                ? 'border-blue-600 text-blue-600'
                 : 'border-transparent text-gray-600 hover:text-gray-900'
             }`}
           >
@@ -536,6 +583,92 @@ export const ClassDetailPage = ({ user }) => {
           </div>
         )}
 
+        {activeTab === 'assignments' && (
+          <div className="bg-white rounded-lg shadow">
+            <div className="p-4 border-b flex justify-between items-center">
+              <h3 className="font-semibold text-gray-900">Assigned Assessments</h3>
+              <button
+                onClick={() => setShowAssignModal(true)}
+                className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 text-sm flex items-center gap-2"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+                </svg>
+                Assign Assessment
+              </button>
+            </div>
+
+            {assignmentsLoading ? (
+              <div className="p-8 text-center text-gray-500">Loading assignments...</div>
+            ) : assignments.length === 0 ? (
+              <div className="p-8 text-center text-gray-500">
+                <p>No assessments assigned to this class yet.</p>
+                <button
+                  onClick={() => setShowAssignModal(true)}
+                  className="mt-4 text-blue-600 hover:underline"
+                >
+                  Assign your first assessment
+                </button>
+              </div>
+            ) : (
+              <div className="divide-y">
+                {assignments.map((assignment) => (
+                  <div key={assignment.id} className="p-4 hover:bg-gray-50">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="min-w-0">
+                        <p className="font-medium text-gray-900 truncate">{assignment.assessment_title}</p>
+                        {assignment.subject && (
+                          <p className="text-sm text-gray-500">{assignment.subject}</p>
+                        )}
+                        <div className="flex items-center gap-3 mt-1">
+                          <span className="text-sm font-mono bg-blue-50 text-blue-700 px-2 py-0.5 rounded">
+                            {assignment.join_code}
+                          </span>
+                          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                            assignment.status === 'open'
+                              ? 'bg-green-100 text-green-700'
+                              : 'bg-gray-100 text-gray-600'
+                          }`}>
+                            {assignment.status === 'open' ? 'Open' : 'Closed'}
+                          </span>
+                        </div>
+                        <p className="text-xs text-gray-500 mt-1">
+                          {assignment.submission_count} submitted · {assignment.marked_count} marked
+                          {assignment.avg_score != null && ` · Avg: ${assignment.avg_score}%`}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <button
+                          onClick={() => handleToggleAssignment(assignment.id, assignment.status)}
+                          className={`px-3 py-1.5 rounded-lg text-sm font-medium ${
+                            assignment.status === 'open'
+                              ? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+                              : 'bg-green-100 text-green-700 hover:bg-green-200'
+                          }`}
+                        >
+                          {assignment.status === 'open' ? 'Close' : 'Reopen'}
+                        </button>
+                        <button
+                          onClick={() => navigate(`/teacher/assignments/${assignment.id}/submissions`)}
+                          className="px-3 py-1.5 rounded-lg text-sm font-medium bg-blue-100 text-blue-700 hover:bg-blue-200"
+                        >
+                          View
+                        </button>
+                        <button
+                          onClick={() => handleDeleteAssignment(assignment.id)}
+                          className="px-3 py-1.5 rounded-lg text-sm font-medium bg-red-100 text-red-700 hover:bg-red-200"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
         {activeTab === 'analytics' && (
           <ClassAnalyticsTab classId={classId} className={classData.class.class_name} />
         )}
@@ -555,7 +688,7 @@ export const ClassDetailPage = ({ user }) => {
 
       {/* Edit Class Modal */}
       {showEditClassModal && (
-        <EditClassModal 
+        <EditClassModal
           classData={classData.class}
           onClose={() => setShowEditClassModal(false)}
           onUpdated={() => {
@@ -564,9 +697,126 @@ export const ClassDetailPage = ({ user }) => {
           }}
         />
       )}
+
+      {/* Assign Assessment Modal */}
+      {showAssignModal && (
+        <AssignAssessmentModal
+          classId={classId}
+          onClose={() => setShowAssignModal(false)}
+          onAssigned={() => {
+            setShowAssignModal(false);
+            setActiveTab('assignments');
+            loadAssignments();
+          }}
+        />
+      )}
     </div>
   );
 };
+
+// Assign Assessment Modal
+const AssignAssessmentModal = ({ classId, onClose, onAssigned }) => {
+  const [assessments, setAssessments] = useState([]);
+  const [selectedId, setSelectedId] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    axios.get(`${API}/teacher/assessments`)
+      .then(res => setAssessments(res.data || []))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleAssign = async () => {
+    if (!selectedId) return;
+    setSaving(true);
+    setError('');
+    try {
+      const res = await axios.post(`${API}/teacher/assessments/${selectedId}/assignments`, { class_id: classId });
+      setResult(res.data);
+    } catch (err) {
+      setError(getApiErrorMessage(err, 'Failed to assign assessment'));
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl max-w-md w-full">
+        <div className="p-6 border-b flex justify-between items-center">
+          <h2 className="text-xl font-bold text-gray-900">Assign Assessment to Class</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="p-6 space-y-4">
+          {result ? (
+            <div className="text-center space-y-3">
+              <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto">
+                <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <p className="font-semibold text-gray-900">Assessment assigned!</p>
+              <p className="text-gray-600 text-sm">{result.assessment_title}</p>
+              <div className="bg-blue-50 rounded-lg p-4">
+                <p className="text-xs text-gray-500 mb-1">Student join code</p>
+                <p className="text-3xl font-mono font-bold text-blue-700 tracking-widest">{result.assignment.join_code}</p>
+                <p className="text-xs text-gray-500 mt-2">Share this code with your students.</p>
+              </div>
+              <button onClick={onAssigned} className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 mt-2">
+                Done
+              </button>
+            </div>
+          ) : (
+            <>
+              {error && <div className="bg-red-50 text-red-700 p-3 rounded-lg text-sm">{error}</div>}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Select Assessment</label>
+                {loading ? (
+                  <p className="text-sm text-gray-500">Loading assessments...</p>
+                ) : assessments.length === 0 ? (
+                  <p className="text-sm text-gray-500">No assessments found. Create an assessment first.</p>
+                ) : (
+                  <select
+                    value={selectedId}
+                    onChange={e => setSelectedId(e.target.value)}
+                    className="w-full border rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="">-- Select an assessment --</option>
+                    {assessments.map(a => (
+                      <option key={a.id} value={a.id}>
+                        {a.title || `Assessment #${a.id.slice(0, 8)}`}
+                        {a.assessmentMode && a.assessmentMode !== 'CLASSIC' ? '' : ''}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </div>
+              <div className="flex gap-3 pt-2">
+                <button onClick={onClose} className="flex-1 bg-gray-100 text-gray-700 py-2 rounded-lg hover:bg-gray-200">Cancel</button>
+                <button
+                  onClick={handleAssign}
+                  disabled={!selectedId || saving}
+                  className="flex-1 bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+                >
+                  {saving ? 'Assigning...' : 'Assign & Generate Code'}
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
 
 // Class Analytics Tab Component
 const ClassAnalyticsTab = ({ classId, className }) => {

--- a/src/components/DiagramRenderer.js
+++ b/src/components/DiagramRenderer.js
@@ -319,7 +319,8 @@ const DiagramRenderer = ({ diagram, className = '' }) => {
         <img
           src={diagram.content}
           alt={diagram.caption || 'Diagram'}
-          className="max-w-full h-auto border rounded shadow-sm"
+          className="max-w-full border rounded shadow-sm"
+          style={{ height: 'auto', maxHeight: '480px', objectFit: 'contain', display: 'block' }}
         />
       );
     case 'venn_diagram':

--- a/src/components/DiagramRenderer.js
+++ b/src/components/DiagramRenderer.js
@@ -300,6 +300,7 @@ const TableDisplay = ({ diagram }) => (
 
 // ── Main Renderer ─────────────────────────────────────────────────────────────
 const DiagramRenderer = ({ diagram, className = '' }) => {
+  const [imgError, setImgError] = React.useState(false);
   if (!diagram) return null;
 
   const { type } = diagram;
@@ -316,12 +317,23 @@ const DiagramRenderer = ({ diagram, className = '' }) => {
   switch (type) {
     case 'image':
       return wrap(
-        <img
-          src={diagram.content}
-          alt={diagram.caption || 'Diagram'}
-          className="max-w-full border rounded shadow-sm"
-          style={{ height: 'auto', maxHeight: '480px', objectFit: 'contain', display: 'block' }}
-        />
+        imgError ? (
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm text-center text-gray-500">
+            <svg className="w-8 h-8 mx-auto mb-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <p>{diagram.caption || 'Image could not be loaded'}</p>
+          </div>
+        ) : (
+          <img
+            src={diagram.content}
+            alt={diagram.caption || 'Diagram'}
+            loading="lazy"
+            className="max-w-full border rounded shadow-sm"
+            style={{ height: 'auto', maxHeight: '480px', objectFit: 'contain', display: 'block' }}
+            onError={() => setImgError(true)}
+          />
+        )
       );
     case 'venn_diagram':
       return wrap(<VennSVG diagram={diagram} />);

--- a/src/components/DrawableCanvas.js
+++ b/src/components/DrawableCanvas.js
@@ -1,0 +1,287 @@
+import { useRef, useState, useEffect, useCallback } from 'react';
+
+const CANVAS_W = 800;
+const CANVAS_H = 550;
+
+// Detect whether question text requires a drawing/graph response.
+// Exported so EnhancedAttemptPage can use it directly.
+export function requiresDrawing(text) {
+  if (!text) return false;
+  const t = text.toLowerCase();
+  return (
+    /\bsketch\b/.test(t) ||
+    /\bdraw\s+(a\s+|the\s+|your\s+)?(histogram|graph|diagram|bar chart|frequency polygon|cumulative frequency|curve|line|circle|triangle|quadrilateral|region|shape)\b/.test(t) ||
+    /\bplot\s+(the\s+|a\s+|your\s+)?(points?|graph|histogram|coordinates|data)\b/.test(t) ||
+    /\bcomplete\s+(the\s+|a\s+)?(histogram|graph|diagram|chart|table)\b/.test(t) ||
+    /\bshade\s+(the\s+|a\s+)?(region|area)\b/.test(t) ||
+    /\bon\s+the\s+(grid|axes|template|diagram|graph)\s+(provided|given|below|above)\b/.test(t)
+  );
+}
+
+const COLORS = [
+  { value: '#1d4ed8', label: 'Blue' },
+  { value: '#dc2626', label: 'Red' },
+  { value: '#15803d', label: 'Green' },
+  { value: '#000000', label: 'Black' },
+];
+
+const DrawableCanvas = ({ backgroundImage, onChange, initialDrawing }) => {
+  const canvasRef = useRef(null);
+  const isDrawingRef = useRef(false);
+  const lastPosRef = useRef({ x: 0, y: 0 });
+  const undoStackRef = useRef([]);
+  const backgroundDataRef = useRef(null); // base64 of background-only snapshot
+
+  const [tool, setTool] = useState('pen');
+  const [color, setColor] = useState('#1d4ed8');
+  const [lineWidth, setLineWidth] = useState(2);
+  const [canUndo, setCanUndo] = useState(false);
+
+  const getPos = (canvas, e) => {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const src = e.touches ? e.touches[0] : e;
+    return {
+      x: (src.clientX - rect.left) * scaleX,
+      y: (src.clientY - rect.top) * scaleY,
+    };
+  };
+
+  const drawBlankGrid = (ctx) => {
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+    // Minor grid lines
+    ctx.strokeStyle = '#e5e7eb';
+    ctx.lineWidth = 0.5;
+    for (let x = 0; x <= CANVAS_W; x += 40) {
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, CANVAS_H); ctx.stroke();
+    }
+    for (let y = 0; y <= CANVAS_H; y += 40) {
+      ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(CANVAS_W, y); ctx.stroke();
+    }
+    // Axes
+    ctx.strokeStyle = '#9ca3af';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath(); ctx.moveTo(CANVAS_W / 2, 0); ctx.lineTo(CANVAS_W / 2, CANVAS_H); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(0, CANVAS_H / 2); ctx.lineTo(CANVAS_W, CANVAS_H / 2); ctx.stroke();
+  };
+
+  const saveUndoState = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const data = canvas.toDataURL();
+    undoStackRef.current.push(data);
+    if (undoStackRef.current.length > 15) undoStackRef.current.shift();
+    setCanUndo(undoStackRef.current.length > 1);
+    onChange?.(data);
+  }, [onChange]);
+
+  // Initialise canvas once on mount / backgroundImage change
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+
+    // If we have a previously saved drawing (full canvas snapshot), restore it directly.
+    // The snapshot already contains the background so we skip re-drawing it.
+    if (initialDrawing) {
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+      const drawImg = new Image();
+      drawImg.onload = () => {
+        ctx.drawImage(drawImg, 0, 0, CANVAS_W, CANVAS_H);
+        const snap = canvas.toDataURL();
+        backgroundDataRef.current = snap;
+        undoStackRef.current = [snap];
+        setCanUndo(false);
+      };
+      drawImg.src = initialDrawing;
+      return;
+    }
+
+    const finishSetup = (baseSnapshot) => {
+      backgroundDataRef.current = baseSnapshot;
+      undoStackRef.current = [baseSnapshot];
+      setCanUndo(false);
+    };
+
+    if (backgroundImage) {
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+      const img = new Image();
+      img.onload = () => {
+        const ratio = Math.min(CANVAS_W / img.width, CANVAS_H / img.height);
+        const w = img.width * ratio;
+        const h = img.height * ratio;
+        ctx.drawImage(img, (CANVAS_W - w) / 2, (CANVAS_H - h) / 2, w, h);
+        finishSetup(canvas.toDataURL());
+      };
+      img.src = backgroundImage;
+    } else {
+      drawBlankGrid(ctx);
+      finishSetup(canvas.toDataURL());
+    }
+  }, [backgroundImage]); // initialDrawing intentionally omitted — only used on first mount
+
+  const startDraw = useCallback((e) => {
+    e.preventDefault();
+    isDrawingRef.current = true;
+    lastPosRef.current = getPos(canvasRef.current, e);
+  }, []);
+
+  const draw = useCallback((e) => {
+    e.preventDefault();
+    if (!isDrawingRef.current) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const pos = getPos(canvas, e);
+    ctx.beginPath();
+    // Eraser draws white (keeps PNG opaque for clean restoration)
+    ctx.strokeStyle = tool === 'eraser' ? '#ffffff' : color;
+    ctx.lineWidth = tool === 'eraser' ? lineWidth * 8 : lineWidth;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.moveTo(lastPosRef.current.x, lastPosRef.current.y);
+    ctx.lineTo(pos.x, pos.y);
+    ctx.stroke();
+    lastPosRef.current = pos;
+  }, [tool, color, lineWidth]);
+
+  const endDraw = useCallback(() => {
+    if (!isDrawingRef.current) return;
+    isDrawingRef.current = false;
+    saveUndoState();
+  }, [saveUndoState]);
+
+  const handleUndo = () => {
+    if (undoStackRef.current.length <= 1) return;
+    undoStackRef.current.pop();
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const img = new Image();
+    const snapshot = undoStackRef.current[undoStackRef.current.length - 1];
+    img.onload = () => {
+      ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+      ctx.drawImage(img, 0, 0);
+      setCanUndo(undoStackRef.current.length > 1);
+      onChange?.(snapshot);
+    };
+    img.src = snapshot;
+  };
+
+  const handleClear = () => {
+    if (!window.confirm('Clear your drawing and start over?')) return;
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const base = backgroundDataRef.current || undoStackRef.current[0];
+    if (!base) return;
+    const img = new Image();
+    img.onload = () => {
+      ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+      ctx.drawImage(img, 0, 0);
+      undoStackRef.current = [base];
+      setCanUndo(false);
+      onChange?.(base);
+    };
+    img.src = base;
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+        <button
+          onClick={() => setTool('pen')}
+          className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+            tool === 'pen' ? 'bg-blue-600 text-white' : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-100'
+          }`}
+        >
+          Pen
+        </button>
+        <button
+          onClick={() => setTool('eraser')}
+          className={`px-3 py-1.5 rounded text-sm font-medium transition-colors ${
+            tool === 'eraser' ? 'bg-orange-500 text-white' : 'bg-white border border-gray-300 text-gray-700 hover:bg-gray-100'
+          }`}
+        >
+          Eraser
+        </button>
+
+        <div className="w-px h-5 bg-gray-300" />
+
+        {COLORS.map(({ value, label }) => (
+          <button
+            key={value}
+            title={label}
+            onClick={() => { setColor(value); setTool('pen'); }}
+            className={`w-6 h-6 rounded-full transition-all ${
+              color === value && tool === 'pen'
+                ? 'ring-2 ring-offset-1 ring-gray-800 scale-110'
+                : 'ring-1 ring-gray-300'
+            }`}
+            style={{ backgroundColor: value }}
+          />
+        ))}
+
+        <div className="w-px h-5 bg-gray-300" />
+
+        <select
+          value={lineWidth}
+          onChange={(e) => setLineWidth(Number(e.target.value))}
+          className="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+        >
+          <option value={1}>Thin</option>
+          <option value={2}>Normal</option>
+          <option value={4}>Thick</option>
+        </select>
+
+        <div className="w-px h-5 bg-gray-300" />
+
+        <button
+          onClick={handleUndo}
+          disabled={!canUndo}
+          className="px-3 py-1.5 rounded text-sm font-medium bg-white border border-gray-300 text-gray-700 hover:bg-gray-100 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          Undo
+        </button>
+        <button
+          onClick={handleClear}
+          className="px-3 py-1.5 rounded text-sm font-medium bg-white border border-gray-300 text-red-600 hover:bg-red-50"
+        >
+          Clear
+        </button>
+      </div>
+
+      {/* Canvas */}
+      <div className="border-2 border-gray-300 rounded-lg overflow-hidden bg-white shadow-sm">
+        <canvas
+          ref={canvasRef}
+          width={CANVAS_W}
+          height={CANVAS_H}
+          style={{
+            width: '100%',
+            height: 'auto',
+            display: 'block',
+            cursor: tool === 'eraser' ? 'cell' : 'crosshair',
+            touchAction: 'none',
+          }}
+          onMouseDown={startDraw}
+          onMouseMove={draw}
+          onMouseUp={endDraw}
+          onMouseLeave={endDraw}
+          onTouchStart={startDraw}
+          onTouchMove={draw}
+          onTouchEnd={endDraw}
+        />
+      </div>
+
+      <p className="text-xs text-gray-500 italic">
+        Draw your answer above. Changes are saved automatically.
+      </p>
+    </div>
+  );
+};
+
+export default DrawableCanvas;

--- a/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
+++ b/src/components/EnhancedAssessmentBuilder/OCRExtractionReview.js
@@ -1,6 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import DiagramRenderer from '../DiagramRenderer';
 import DiagramCropModal from './DiagramCropModal';
+import LaTeXRenderer from '../LaTeXRenderer';
 
 // ─── Confidence helpers ───────────────────────────────────────────────────────
 
@@ -11,8 +12,6 @@ const getConfidenceTier = (score) => {
   return 'low';
 };
 
-// A question with an unresolved missing-diagram flag is always "needs review",
-// regardless of how high its raw confidence score is.
 const getEffectiveTier = (question) => {
   const tier = getConfidenceTier(question.extractionConfidence);
   if (
@@ -25,15 +24,25 @@ const getEffectiveTier = (question) => {
   return tier;
 };
 
+// A question needs attention when its confidence is not high, OR when its mark
+// scheme is missing (extraction succeeded but no mark scheme was found for it).
+const questionNeedsAttention = (q) => {
+  if (getEffectiveTier(q) !== 'high') return true;
+  if (q.questionType === 'STRUCTURED_WITH_PARTS') {
+    return (q.parts || []).some(p => !p.markScheme?.trim());
+  }
+  return !q.markScheme?.trim();
+};
+
 const ConfidenceBadge = ({ question }) => {
   const tier = getEffectiveTier(question);
-  const pct = question.extractionConfidence !== null && question.extractionConfidence !== undefined
+  const pct = question.extractionConfidence != null
     ? Math.round(question.extractionConfidence * 100) : null;
 
   const styles = {
-    high: 'bg-green-100 text-green-800 border-green-200',
-    medium: 'bg-amber-100 text-amber-800 border-amber-200',
-    low: 'bg-red-100 text-red-800 border-red-200',
+    high:    'bg-green-100 text-green-800 border-green-200',
+    medium:  'bg-amber-100 text-amber-800 border-amber-200',
+    low:     'bg-red-100 text-red-800 border-red-200',
     unknown: 'bg-gray-100 text-gray-600 border-gray-200',
   };
   const labels = {
@@ -54,14 +63,51 @@ const ConfidenceBadge = ({ question }) => {
 };
 
 const FLAG_LABELS = {
-  marks_not_found: 'Marks not found — please set manually',
-  question_number_unclear: 'Question number unclear',
-  question_text_very_short: 'Question text is very short',
+  marks_not_found:              'Marks not found — please set manually',
+  question_number_unclear:      'Question number unclear',
+  question_text_very_short:     'Question text is very short',
   diagram_referenced_but_missing: 'Diagram referenced but not extracted',
-  scanned_page_fallback: 'Extracted via Vision (scanned page)',
+  scanned_page_fallback:        'Extracted via Vision (scanned page)',
 };
 
-// ─── Inline edit form for a single question ───────────────────────────────────
+// ─── Mark scheme image panel ──────────────────────────────────────────────────
+
+const MarkSchemeImagePanel = ({ msPageNum, msPageThumbnails }) => {
+  const [open, setOpen] = useState(false);
+
+  if (!msPageNum || !msPageThumbnails) return null;
+  const src = msPageThumbnails[String(msPageNum)];
+  if (!src) return null;
+
+  return (
+    <div className="mt-2 border border-blue-200 rounded-lg overflow-hidden bg-blue-50">
+      <button
+        onClick={() => setOpen(v => !v)}
+        className="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-blue-800 hover:bg-blue-100 transition-colors"
+      >
+        <span className="flex items-center gap-1.5">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2"/><polyline points="3 9 21 9"/><polyline points="9 21 9 9"/>
+          </svg>
+          View mark scheme (page {msPageNum})
+        </span>
+        <span>{open ? '▲' : '▼'}</span>
+      </button>
+      {open && (
+        <div className="border-t border-blue-200 bg-white">
+          <img
+            src={src}
+            alt={`Mark scheme page ${msPageNum}`}
+            className="w-full block"
+            style={{ height: 'auto' }}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Inline edit form ─────────────────────────────────────────────────────────
 
 const inputCls = "w-full px-2 py-1.5 text-sm border border-gray-300 rounded focus:ring-1 focus:ring-blue-500 focus:border-blue-500";
 
@@ -118,17 +164,22 @@ const QuestionInlineEditor = ({ question, onChange }) => {
               </select>
             </div>
           </div>
-          {question.markScheme && (
-            <div>
-              <label className="block text-xs font-medium text-gray-600 mb-1">Mark scheme (pre-filled from PDF)</label>
-              <textarea
-                value={question.markScheme}
-                onChange={(e) => handleField('markScheme', e.target.value)}
-                rows={2}
-                className={`${inputCls} font-mono`}
-              />
-            </div>
-          )}
+          <div>
+            <label className="block text-xs font-medium text-gray-600 mb-1">
+              Mark scheme
+              {question.markScheme?.trim()
+                ? <span className="ml-1 text-green-600 font-normal">(pre-filled from PDF)</span>
+                : <span className="ml-1 text-amber-600 font-normal">(not extracted — enter manually)</span>
+              }
+            </label>
+            <textarea
+              value={question.markScheme || ''}
+              onChange={(e) => handleField('markScheme', e.target.value)}
+              rows={3}
+              placeholder="Enter the mark scheme here..."
+              className={`${inputCls} font-mono`}
+            />
+          </div>
         </>
       )}
 
@@ -166,17 +217,22 @@ const QuestionInlineEditor = ({ question, onChange }) => {
                   />
                 </div>
               </div>
-              {part.markScheme && (
-                <div>
-                  <label className="block text-xs font-medium text-gray-600 mb-1">Mark scheme</label>
-                  <textarea
-                    value={part.markScheme}
-                    onChange={(e) => handlePartField(partIdx, 'markScheme', e.target.value)}
-                    rows={2}
-                    className={`${inputCls} font-mono`}
-                  />
-                </div>
-              )}
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  Mark scheme
+                  {part.markScheme?.trim()
+                    ? <span className="ml-1 text-green-600 font-normal">(pre-filled)</span>
+                    : <span className="ml-1 text-amber-600 font-normal">(not extracted)</span>
+                  }
+                </label>
+                <textarea
+                  value={part.markScheme || ''}
+                  onChange={(e) => handlePartField(partIdx, 'markScheme', e.target.value)}
+                  rows={2}
+                  placeholder="Enter the mark scheme for this part..."
+                  className={`${inputCls} font-mono`}
+                />
+              </div>
             </div>
           ))}
         </div>
@@ -187,11 +243,18 @@ const QuestionInlineEditor = ({ question, onChange }) => {
 
 // ─── Single question card ─────────────────────────────────────────────────────
 
-const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, pageImages }) => {
+const QuestionCard = ({
+  question, index, total,
+  onMove, onChange, onRemove,
+  pageImages, msPageThumbnails,
+  isReviewed, onMarkReviewed,
+}) => {
   const [expanded, setExpanded] = useState(false);
   const [cropModalOpen, setCropModalOpen] = useState(false);
+
   const tier = getEffectiveTier(question);
   const flags = question.extractionFlags || [];
+  const needsAttention = questionNeedsAttention(question);
 
   const pageImage = pageImages && question.page_num
     ? pageImages[String(question.page_num)]
@@ -199,11 +262,13 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
 
   const handleCropConfirm = (newStimulus) => {
     onChange(index, { ...question, stimulusBlock: newStimulus });
+    onMarkReviewed(index);
     setCropModalOpen(false);
   };
 
   const handleRemoveDiagram = () => {
     onChange(index, { ...question, stimulusBlock: null });
+    onMarkReviewed(index);
     setCropModalOpen(false);
   };
 
@@ -212,21 +277,39 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
       ...question,
       extractionFlags: (question.extractionFlags || []).filter(f => f !== 'diagram_referenced_but_missing'),
     });
+    onMarkReviewed(index);
+  };
+
+  const handleInlineChange = (updated) => {
+    onChange(index, updated);
+    onMarkReviewed(index);
+  };
+
+  const handleExpand = () => {
+    setExpanded(v => !v);
+    // Opening the edit panel counts as starting review
+    if (!expanded) onMarkReviewed(index);
   };
 
   const isMissingDiagram = flags.includes('diagram_referenced_but_missing') && !question.stimulusBlock;
 
-  const borderColor = {
-    high: 'border-l-green-400',
-    medium: 'border-l-amber-400',
-    low: 'border-l-red-400',
-    unknown: 'border-l-gray-300',
-  }[tier];
+  const hasSubParts = question.questionType === 'STRUCTURED_WITH_PARTS' && question.parts?.length > 0;
+  const missingMarkScheme = hasSubParts
+    ? (question.parts || []).some(p => !p.markScheme?.trim())
+    : !question.markScheme?.trim();
+
+  // Border: red when needing attention and not yet reviewed; green once reviewed; gray otherwise
+  let borderLeft;
+  if (needsAttention && !isReviewed) {
+    borderLeft = 'border-l-red-500';
+  } else if (isReviewed) {
+    borderLeft = 'border-l-green-500';
+  } else {
+    borderLeft = 'border-l-green-400';
+  }
 
   const bodyText = (question.questionBody || question.question_text || '').trim();
   const preview = bodyText.length > 100 ? bodyText.slice(0, 100) + '…' : bodyText;
-
-  const hasSubParts = question.questionType === 'STRUCTURED_WITH_PARTS' && question.parts?.length > 0;
 
   return (
     <>
@@ -239,7 +322,7 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
         onClose={() => setCropModalOpen(false)}
       />
     )}
-    <div className={`bg-white rounded-lg border-l-4 border border-gray-200 ${borderColor} shadow-sm`}>
+    <div className={`bg-white rounded-lg border-l-4 border border-gray-200 ${borderLeft} shadow-sm`}>
       <div className="p-4">
         <div className="flex items-start gap-3">
           {/* Reorder buttons */}
@@ -249,17 +332,13 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
               disabled={index === 0}
               title="Move up"
               className="p-0.5 rounded text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed"
-            >
-              ▲
-            </button>
+            >▲</button>
             <button
               onClick={() => onMove(index, index + 1)}
               disabled={index === total - 1}
               title="Move down"
               className="p-0.5 rounded text-gray-400 hover:text-gray-700 disabled:opacity-20 disabled:cursor-not-allowed"
-            >
-              ▼
-            </button>
+            >▼</button>
           </div>
 
           {/* Question number badge */}
@@ -286,11 +365,23 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
                   Has diagram
                 </span>
               )}
+              {missingMarkScheme && (
+                <span className="text-xs text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded">
+                  Mark scheme missing
+                </span>
+              )}
+              {isReviewed && (
+                <span className="text-xs text-green-700 bg-green-50 border border-green-200 px-1.5 py-0.5 rounded">
+                  ✓ Reviewed
+                </span>
+              )}
             </div>
 
-            <p className="text-sm text-gray-800 leading-snug">
-              {preview || <span className="italic text-gray-400">No question text extracted</span>}
-            </p>
+            <div className="text-sm text-gray-800 leading-snug">
+              {bodyText
+                ? <LaTeXRenderer text={preview} />
+                : <span className="italic text-gray-400">No question text extracted</span>}
+            </div>
 
             {flags.length > 0 && (
               <ul className="mt-1.5 space-y-0.5">
@@ -298,8 +389,7 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
                   .filter(f => f !== 'diagram_referenced_but_missing')
                   .map((flag) => (
                     <li key={flag} className="text-xs text-amber-700 flex items-center gap-1">
-                      <span>⚠</span>
-                      {FLAG_LABELS[flag] || flag}
+                      <span>⚠</span> {FLAG_LABELS[flag] || flag}
                     </li>
                   ))}
               </ul>
@@ -308,7 +398,7 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
 
           <div className="flex items-center gap-1 shrink-0">
             <button
-              onClick={() => setExpanded((v) => !v)}
+              onClick={handleExpand}
               className="px-2 py-1 text-xs text-blue-600 hover:text-blue-800 border border-blue-200 rounded hover:bg-blue-50"
             >
               {expanded ? 'Collapse' : 'Edit'}
@@ -317,9 +407,7 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
               onClick={() => onRemove(index)}
               title="Remove question"
               className="px-2 py-1 text-xs text-red-500 hover:text-red-700 border border-red-200 rounded hover:bg-red-50"
-            >
-              ✕
-            </button>
+            >✕</button>
           </div>
         </div>
 
@@ -351,11 +439,11 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
           </div>
         )}
 
-        {/* Diagram preview + crop controls */}
+        {/* Collapsed view: diagram preview + mark scheme image */}
         {!expanded && (
-          <div className="mt-2 ml-10">
+          <div className="mt-2 ml-10 space-y-1">
             {question.stimulusBlock && (
-              <div className="max-w-xs border border-gray-200 rounded overflow-hidden mb-1">
+              <div className="max-w-xs border border-gray-200 rounded overflow-hidden">
                 <DiagramRenderer diagram={question.stimulusBlock} />
               </div>
             )}
@@ -366,26 +454,25 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
                     <button
                       onClick={() => setCropModalOpen(true)}
                       className="text-xs text-blue-600 hover:text-blue-800 border border-blue-200 rounded px-2 py-0.5 hover:bg-blue-50"
-                    >
-                      ✂ Fix crop
-                    </button>
+                    >✂ Fix crop</button>
                     <button
                       onClick={handleRemoveDiagram}
                       className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-2 py-0.5 hover:bg-red-50"
-                    >
-                      Remove diagram
-                    </button>
+                    >Remove diagram</button>
                   </>
                 ) : (
                   <button
                     onClick={() => setCropModalOpen(true)}
                     className="text-xs text-gray-600 hover:text-gray-900 border border-gray-300 rounded px-2 py-0.5 hover:bg-gray-50"
-                  >
-                    + Add diagram crop
-                  </button>
+                  >+ Add diagram crop</button>
                 )}
               </div>
             )}
+            {/* Mark scheme page image — always visible so teacher can check without expanding */}
+            <MarkSchemeImagePanel
+              msPageNum={question.msPageNum}
+              msPageThumbnails={msPageThumbnails}
+            />
           </div>
         )}
 
@@ -410,13 +497,16 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
                   <button
                     onClick={handleRemoveDiagram}
                     className="text-xs text-red-500 hover:text-red-700 border border-red-200 rounded px-2 py-0.5 hover:bg-red-50"
-                  >
-                    Remove diagram
-                  </button>
+                  >Remove diagram</button>
                 )}
               </div>
             )}
-            <QuestionInlineEditor question={question} onChange={(updated) => onChange(index, updated)} />
+            {/* Mark scheme page image — open by default when editing */}
+            <MarkSchemeImagePanel
+              msPageNum={question.msPageNum}
+              msPageThumbnails={msPageThumbnails}
+            />
+            <QuestionInlineEditor question={question} onChange={handleInlineChange} />
           </div>
         )}
       </div>
@@ -425,7 +515,7 @@ const QuestionCard = ({ question, index, total, onMove, onChange, onRemove, page
   );
 };
 
-// ─── Source pages panel (side-by-side reference) ──────────────────────────────
+// ─── Source pages panel ───────────────────────────────────────────────────────
 
 const SourcePagesPanel = ({ thumbnails }) => {
   const [open, setOpen] = useState(false);
@@ -451,7 +541,6 @@ const SourcePagesPanel = ({ thumbnails }) => {
 
       {open && (
         <div className="border-t border-gray-100">
-          {/* Thumbnail strip */}
           <div className="flex gap-2 p-3 overflow-x-auto bg-gray-50">
             {entries.map(([pageNum, src]) => (
               <button
@@ -467,16 +556,11 @@ const SourcePagesPanel = ({ thumbnails }) => {
               </button>
             ))}
           </div>
-
-          {/* Expanded view of selected page */}
           {selected && thumbnails[selected] && (
             <div className="p-4 border-t border-gray-100 bg-white">
               <div className="flex items-center justify-between mb-2">
                 <span className="text-sm font-medium text-gray-700">Page {selected}</span>
-                <button
-                  onClick={() => setSelected(null)}
-                  className="text-xs text-gray-400 hover:text-gray-600"
-                >
+                <button onClick={() => setSelected(null)} className="text-xs text-gray-400 hover:text-gray-600">
                   Close ✕
                 </button>
               </div>
@@ -496,35 +580,39 @@ const SourcePagesPanel = ({ thumbnails }) => {
 
 // ─── Main review component ────────────────────────────────────────────────────
 
-/**
- * OCRExtractionReview
- *
- * Presents extracted questions with confidence badges for teacher review
- * before the assessment is finalised. Prevents auto-confirmation.
- *
- * Props:
- *   questions          – array of extracted question objects
- *   extractionSummary  – { avg_confidence, high_confidence, medium_confidence, low_confidence }
- *   pageThumbnails     – { "1": "data:image/jpeg;base64,...", "2": ... } — original page images
- *   onConfirm(qs)      – called with (possibly edited) questions when teacher confirms
- *   onBack()           – called when teacher wants to go back and re-upload
- */
-const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, pageImages, onConfirm, onBack }) => {
+const OCRExtractionReview = ({
+  questions: initialQuestions,
+  pageThumbnails,
+  pageImages,
+  msPageThumbnails,
+  onConfirm,
+  onBack,
+}) => {
   const [questions, setQuestions] = useState(() =>
     (initialQuestions || []).map((q, i) => ({ ...q, questionNumber: i + 1 }))
   );
-  const [filterTier, setFilterTier] = useState('all'); // 'all' | 'high' | 'medium' | 'low'
+  const [filterTier, setFilterTier] = useState('all');
+  // Set of question indices the teacher has opened for editing
+  const [reviewedSet, setReviewedSet] = useState(() => new Set());
 
-  // Always recompute from live question state so that resolving a missing diagram
-  // (via crop or Skip) immediately updates the summary counts and filter bar.
-  const highCount = questions.filter((q) => getEffectiveTier(q) === 'high').length;
-  const medCount  = questions.filter((q) => getEffectiveTier(q) === 'medium').length;
-  const lowCount  = questions.filter((q) => getEffectiveTier(q) === 'low').length;
-  const needsReview = lowCount + medCount;
+  const markReviewed = useCallback((idx) => {
+    setReviewedSet(prev => {
+      if (prev.has(idx)) return prev;
+      return new Set([...prev, idx]);
+    });
+  }, []);
+
+  // Counts based on live question state
+  const highCount    = questions.filter(q => getEffectiveTier(q) === 'high').length;
+  const medCount     = questions.filter(q => getEffectiveTier(q) === 'medium').length;
+  const lowCount     = questions.filter(q => getEffectiveTier(q) === 'low').length;
+  // Include questions with missing mark scheme in the attention count, avoiding double-counting
+  const attentionCount = questions.filter(questionNeedsAttention).length;
+  const unreviewedCount = questions.filter((q, i) => questionNeedsAttention(q) && !reviewedSet.has(i)).length;
 
   const moveQuestion = useCallback((fromIdx, toIdx) => {
     if (toIdx < 0 || toIdx >= questions.length) return;
-    setQuestions((prev) => {
+    setQuestions(prev => {
       const next = [...prev];
       const [moved] = next.splice(fromIdx, 1);
       next.splice(toIdx, 0, moved);
@@ -533,7 +621,7 @@ const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, page
   }, [questions.length]);
 
   const updateQuestion = useCallback((idx, updated) => {
-    setQuestions((prev) => {
+    setQuestions(prev => {
       const next = [...prev];
       next[idx] = { ...updated, questionNumber: idx + 1 };
       return next;
@@ -541,15 +629,23 @@ const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, page
   }, []);
 
   const removeQuestion = useCallback((idx) => {
-    setQuestions((prev) => {
+    setQuestions(prev => {
       const next = prev.filter((_, i) => i !== idx);
       return next.map((q, i) => ({ ...q, questionNumber: i + 1 }));
+    });
+    // Re-map reviewedSet indices after removal
+    setReviewedSet(prev => {
+      const next = new Set();
+      prev.forEach(i => { if (i < idx) next.add(i); else if (i > idx) next.add(i - 1); });
+      return next;
     });
   }, []);
 
   const filteredQuestions = filterTier === 'all'
     ? questions
-    : questions.filter((q) => getEffectiveTier(q) === filterTier);
+    : filterTier === 'attention'
+    ? questions.filter(questionNeedsAttention)
+    : questions.filter(q => getEffectiveTier(q) === filterTier);
 
   return (
     <div className="space-y-4">
@@ -559,7 +655,7 @@ const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, page
           <div>
             <h3 className="text-lg font-semibold text-gray-900">Review Extracted Questions</h3>
             <p className="text-sm text-gray-500 mt-0.5">
-              Check every question before confirming. Low-confidence items need your attention.
+              Check every question before confirming. Questions highlighted in red need your attention.
             </p>
           </div>
           <button
@@ -580,46 +676,77 @@ const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, page
             <span className="font-semibold text-green-800">{highCount}</span>
             <span className="text-green-700">high confidence</span>
           </div>
-          <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 rounded-lg border border-amber-200 text-sm">
-            <span className="font-semibold text-amber-800">{medCount}</span>
-            <span className="text-amber-700">need review</span>
-          </div>
+          {medCount > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 rounded-lg border border-amber-200 text-sm">
+              <span className="font-semibold text-amber-800">{medCount}</span>
+              <span className="text-amber-700">medium confidence</span>
+            </div>
+          )}
           {lowCount > 0 && (
             <div className="flex items-center gap-2 px-3 py-2 bg-red-50 rounded-lg border border-red-200 text-sm">
               <span className="font-semibold text-red-800">{lowCount}</span>
               <span className="text-red-700">low confidence</span>
             </div>
           )}
+          {attentionCount > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-red-50 rounded-lg border border-red-300 text-sm">
+              <span className="font-semibold text-red-800">{attentionCount}</span>
+              <span className="text-red-700">need review</span>
+              {unreviewedCount < attentionCount && (
+                <span className="text-green-700 ml-1">· {attentionCount - unreviewedCount} reviewed</span>
+              )}
+            </div>
+          )}
         </div>
 
-        {needsReview > 0 && (
-          <div className="mt-3 p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-800">
-            ⚠ <strong>{needsReview} question{needsReview !== 1 ? 's' : ''}</strong> need your attention. Click <strong>Edit</strong> on each highlighted question to check and correct the extracted text.
+        {/* Attention banner — shown until all flagged questions have been reviewed */}
+        {unreviewedCount > 0 && (
+          <div className="mt-3 p-3 bg-red-50 border border-red-300 rounded-lg flex items-start gap-3">
+            <span className="text-red-500 text-lg shrink-0">⚠</span>
+            <div>
+              <p className="text-sm font-semibold text-red-800">
+                {unreviewedCount} question{unreviewedCount !== 1 ? 's' : ''} need{unreviewedCount === 1 ? 's' : ''} your attention
+              </p>
+              <p className="text-xs text-red-700 mt-0.5">
+                Questions with a red border have low extraction confidence or a missing mark scheme.
+                Click <strong>Edit</strong> on each one to verify and correct the extracted text, then enter any missing mark scheme.
+              </p>
+            </div>
+          </div>
+        )}
+        {unreviewedCount === 0 && attentionCount > 0 && (
+          <div className="mt-3 p-3 bg-green-50 border border-green-300 rounded-lg flex items-center gap-2">
+            <span className="text-green-600">✓</span>
+            <p className="text-sm text-green-800 font-medium">All flagged questions have been reviewed.</p>
           </div>
         )}
       </div>
 
-      {/* Source pages side-by-side panel */}
+      {/* Source pages panel */}
       <SourcePagesPanel thumbnails={pageThumbnails} />
 
       {/* Filter bar */}
-      <div className="flex gap-2">
-        {['all', 'high', 'medium', 'low'].map((tier) => (
+      <div className="flex gap-2 flex-wrap">
+        {[
+          { key: 'all',       label: 'All',            count: questions.length },
+          { key: 'attention', label: 'Needs attention', count: attentionCount },
+          { key: 'high',      label: 'High confidence', count: highCount },
+          { key: 'medium',    label: 'Medium',          count: medCount },
+          { key: 'low',       label: 'Low',             count: lowCount },
+        ].filter(f => f.key === 'all' || f.key === 'attention' || f.count > 0).map(({ key, label, count }) => (
           <button
-            key={tier}
-            onClick={() => setFilterTier(tier)}
+            key={key}
+            onClick={() => setFilterTier(key)}
             className={`px-3 py-1.5 text-sm rounded-lg border transition-colors ${
-              filterTier === tier
-                ? 'bg-blue-600 text-white border-blue-600'
+              filterTier === key
+                ? key === 'attention' || key === 'low'
+                  ? 'bg-red-600 text-white border-red-600'
+                  : 'bg-blue-600 text-white border-blue-600'
                 : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-50'
             }`}
           >
-            {tier === 'all' ? 'All' : tier.charAt(0).toUpperCase() + tier.slice(1)}
-            {tier !== 'all' && (
-              <span className="ml-1 opacity-70">
-                ({tier === 'high' ? highCount : tier === 'medium' ? medCount : lowCount})
-              </span>
-            )}
+            {label}
+            {key !== 'all' && <span className="ml-1 opacity-70">({count})</span>}
           </button>
         ))}
       </div>
@@ -643,6 +770,9 @@ const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, page
                 onChange={updateQuestion}
                 onRemove={removeQuestion}
                 pageImages={pageImages}
+                msPageThumbnails={msPageThumbnails}
+                isReviewed={reviewedSet.has(realIdx)}
+                onMarkReviewed={markReviewed}
               />
             );
           })}
@@ -652,14 +782,20 @@ const OCRExtractionReview = ({ questions: initialQuestions, pageThumbnails, page
       {/* Sticky confirm bar */}
       <div className="sticky bottom-0 bg-white border-t shadow-lg rounded-b-lg px-5 py-4 flex items-center justify-between gap-4">
         <div className="text-sm text-gray-600">
-          {questions.length} question{questions.length !== 1 ? 's' : ''} ready to edit
-          {needsReview > 0 && (
-            <span className="ml-2 text-amber-700">· {needsReview} still need review</span>
+          {unreviewedCount > 0 ? (
+            <span className="text-red-600 font-medium">
+              Review {unreviewedCount} remaining question{unreviewedCount !== 1 ? 's' : ''} before continuing
+            </span>
+          ) : (
+            <span className="text-green-700 font-medium">
+              {questions.length} question{questions.length !== 1 ? 's' : ''} ready — all reviewed
+            </span>
           )}
         </div>
         <button
           onClick={() => onConfirm(questions)}
-          disabled={questions.length === 0}
+          disabled={questions.length === 0 || unreviewedCount > 0}
+          title={unreviewedCount > 0 ? `${unreviewedCount} question${unreviewedCount !== 1 ? 's' : ''} still need review` : undefined}
           className="px-6 py-2.5 bg-green-600 text-white rounded-lg hover:bg-green-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
         >
           Confirm &amp; Edit Questions →

--- a/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
+++ b/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
@@ -203,9 +203,8 @@ const QuestionEditor = ({
                   <StructuredQuestionBuilder
                     parts={question.parts || []}
                     onPartsChange={(parts) => {
-                      updateQuestion('parts', parts);
                       const totalMarks = parts.reduce((sum, p) => sum + (p.maxMarks || 0), 0);
-                      updateQuestion('maxMarks', totalMarks);
+                      onQuestionChange(questionIndex, { ...question, parts, maxMarks: totalMarks });
                     }}
                     questionNumber={question.questionNumber}
                   />
@@ -277,26 +276,6 @@ const QuestionEditor = ({
 
                 {/* Additional Options */}
                 <div className="flex flex-wrap items-center gap-4">
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={question.calculatorAllowed || false}
-                      onChange={(e) => updateQuestion('calculatorAllowed', e.target.checked)}
-                      className="rounded"
-                    />
-                    <span className="text-sm">Calculator allowed</span>
-                  </label>
-
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={question.mathKeyboardEnabled || false}
-                      onChange={(e) => updateQuestion('mathKeyboardEnabled', e.target.checked)}
-                      className="rounded"
-                    />
-                    <span className="text-sm">Maths keyboard for students</span>
-                  </label>
-
                   <div className="flex items-center gap-2">
                     <span className="text-sm text-gray-700">Drawing canvas:</span>
                     <select

--- a/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
+++ b/src/components/EnhancedAssessmentBuilder/QuestionEditor.js
@@ -276,7 +276,7 @@ const QuestionEditor = ({
                 )}
 
                 {/* Additional Options */}
-                <div className="flex items-center gap-2">
+                <div className="flex flex-wrap items-center gap-4">
                   <label className="flex items-center gap-2">
                     <input
                       type="checkbox"
@@ -286,6 +286,32 @@ const QuestionEditor = ({
                     />
                     <span className="text-sm">Calculator allowed</span>
                   </label>
+
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={question.mathKeyboardEnabled || false}
+                      onChange={(e) => updateQuestion('mathKeyboardEnabled', e.target.checked)}
+                      className="rounded"
+                    />
+                    <span className="text-sm">Maths keyboard for students</span>
+                  </label>
+
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-gray-700">Drawing canvas:</span>
+                    <select
+                      value={question.drawingEnabled === true ? 'on' : question.drawingEnabled === false ? 'off' : 'auto'}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        updateQuestion('drawingEnabled', v === 'auto' ? null : v === 'on');
+                      }}
+                      className="text-sm border border-gray-300 rounded px-2 py-1"
+                    >
+                      <option value="auto">Auto-detect</option>
+                      <option value="on">Always show</option>
+                      <option value="off">Disabled</option>
+                    </select>
+                  </div>
                 </div>
               </>
             )}

--- a/src/components/EnhancedAssessmentBuilder/StructuredQuestionBuilder.js
+++ b/src/components/EnhancedAssessmentBuilder/StructuredQuestionBuilder.js
@@ -150,6 +150,25 @@ const StructuredQuestionBuilder = ({ parts, onPartsChange, questionNumber }) => 
                     </div>
                   </div>
 
+                  {/* Part options */}
+                  <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm text-gray-700">Drawing:</span>
+                      <select
+                        value={part.drawingEnabled === true ? 'on' : part.drawingEnabled === false ? 'off' : 'auto'}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          updatePart(index, 'drawingEnabled', v === 'auto' ? null : v === 'on');
+                        }}
+                        className="text-sm border border-gray-300 rounded px-2 py-1"
+                      >
+                        <option value="auto">Auto-detect</option>
+                        <option value="on">Always show</option>
+                        <option value="off">Disabled</option>
+                      </select>
+                    </div>
+                  </div>
+
                   {/* Mark Scheme */}
                   <div>
                     <div className="flex items-center justify-between mb-1">

--- a/src/components/EnhancedAssessmentBuilder/StructuredQuestionBuilder.js
+++ b/src/components/EnhancedAssessmentBuilder/StructuredQuestionBuilder.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import LaTeXRenderer from '../LaTeXRenderer';
+import DiagramRenderer from '../DiagramRenderer';
 
 const LaTeXPreview = ({ text, label }) => {
   if (!text || !text.includes('$')) return null;
@@ -121,6 +122,23 @@ const StructuredQuestionBuilder = ({ parts, onPartsChange, questionNumber }) => 
                     />
                     <LaTeXPreview text={part.partPrompt} label={`part ${part.partLabel}`} />
                   </div>
+
+                  {/* Extracted diagram for this part — teacher can remove if incorrectly assigned */}
+                  {part.partStimulus && (
+                    <div className="border border-amber-200 bg-amber-50 rounded-lg p-3">
+                      <div className="flex items-center justify-between mb-2">
+                        <p className="text-xs font-medium text-amber-700">Extracted diagram for part ({part.partLabel})</p>
+                        <button
+                          type="button"
+                          onClick={() => updatePart(index, 'partStimulus', null)}
+                          className="text-xs text-red-600 hover:text-red-800 hover:underline"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                      <DiagramRenderer diagram={part.partStimulus} />
+                    </div>
+                  )}
 
                   {/* Marks and Answer Type */}
                   <div className="grid grid-cols-2 gap-3">

--- a/src/components/LaTeXRenderer.js
+++ b/src/components/LaTeXRenderer.js
@@ -3,53 +3,51 @@ import katex from 'katex';
 import 'katex/dist/katex.min.css';
 
 const LaTeXRenderer = ({ text, block = false, inline = false }) => {
-  // Ensure text is a string
   if (!text) return null;
   if (typeof text !== 'string') {
     console.error('LaTeXRenderer: text prop must be a string, received:', typeof text, text);
     return <span className="text-red-600">Error: Invalid content type</span>;
   }
 
-  // Function to render LaTeX within text
+  const renderKatex = (latex, displayMode, key) => {
+    try {
+      const html = katex.renderToString(latex, { displayMode, throwOnError: false });
+      return displayMode
+        ? <div key={key} dangerouslySetInnerHTML={{ __html: html }} className="my-2" />
+        : <span key={key} dangerouslySetInnerHTML={{ __html: html }} />;
+    } catch {
+      return <span key={key}>{latex}</span>;
+    }
+  };
+
+  // Normalise \(...\) → $...$ and \[...\] → $$...$$ so the splitter below handles all formats.
+  const normalise = (s) =>
+    s
+      .replace(/\\\[([\s\S]*?)\\\]/g, (_, m) => `$$${m}$$`)
+      .replace(/\\\(([\s\S]*?)\\\)/g, (_, m) => `$${m}$`);
+
   const renderMathText = (content) => {
     if (!content || typeof content !== 'string') return '';
 
-    // Split by display math ($$...$$)
-    const displayParts = content.split(/(\$\$[\s\S]*?\$\$)/g);
-    
+    const normalised = normalise(content);
+
+    // Split by display math ($$...$$) first
+    const displayParts = normalised.split(/(\$\$[\s\S]*?\$\$)/g);
+
     return displayParts.map((part, index) => {
-      // Check if this is display math
       if (part.startsWith('$$') && part.endsWith('$$')) {
-        const latex = part.slice(2, -2).trim();
-        try {
-          const html = katex.renderToString(latex, {
-            displayMode: true,
-            throwOnError: false,
-          });
-          return <div key={index} dangerouslySetInnerHTML={{ __html: html }} className="my-2" />;
-        } catch (e) {
-          return <span key={index} className="text-red-600">{part}</span>;
-        }
+        return renderKatex(part.slice(2, -2).trim(), true, index);
       }
 
-      // Split by inline math ($...$)
+      // Split remainder by inline math ($...$)
       const inlineParts = part.split(/(\$[^$]+?\$)/g);
-      
+
       return inlineParts.map((inlinePart, inlineIndex) => {
         if (inlinePart.startsWith('$') && inlinePart.endsWith('$') && inlinePart.length > 2) {
-          const latex = inlinePart.slice(1, -1);
-          try {
-            const html = katex.renderToString(latex, {
-              displayMode: false,
-              throwOnError: false,
-            });
-            return <span key={`${index}-${inlineIndex}`} dangerouslySetInnerHTML={{ __html: html }} />;
-          } catch (e) {
-            return <span key={`${index}-${inlineIndex}`} className="text-red-600">{inlinePart}</span>;
-          }
+          return renderKatex(inlinePart.slice(1, -1), false, `${index}-${inlineIndex}`);
         }
-        
-        // Regular text - preserve line breaks
+
+        // Plain text — preserve newlines
         return inlinePart.split('\n').map((line, lineIndex, arr) => (
           <React.Fragment key={`${index}-${inlineIndex}-${lineIndex}`}>
             {line}

--- a/src/components/QuestionSidebar.js
+++ b/src/components/QuestionSidebar.js
@@ -6,16 +6,19 @@ const QuestionSidebar = ({
   timeLeft,
   answers,
   currentQuestionIndex,
+  flaggedQuestions = new Set(),
   onGoToQuestion,
+  onToggleFlag,
   onSubmit,
   submitting,
   isSaving,
   answerProgress,
 }) => {
   const { answeredCount, totalItems } = answerProgress;
+  const flaggedCount = flaggedQuestions.size;
 
   return (
-    <div className="w-64 bg-white border-r border-gray-200 p-4 overflow-y-auto">
+    <div className="w-64 bg-white border-r border-gray-200 p-4 flex flex-col h-screen sticky top-0">
       <div className="mb-6">
         <h2 className="text-lg font-bold text-gray-900 mb-1">{assessment.title}</h2>
         <p className="text-sm text-gray-600">{assessment.subject}</p>
@@ -26,7 +29,7 @@ const QuestionSidebar = ({
 
       {/* Timer */}
       {timeLeft !== null && (
-        <div className={`mb-6 p-3 rounded-lg ${timeLeft < 300 ? 'bg-red-50 border border-red-200' : 'bg-blue-50 border border-blue-200'}`}>
+        <div className={`mb-4 p-3 rounded-lg ${timeLeft < 300 ? 'bg-red-50 border border-red-200' : 'bg-blue-50 border border-blue-200'}`}>
           <p className="text-xs text-gray-600 mb-1">Time Remaining</p>
           <p className={`text-2xl font-bold ${timeLeft < 300 ? 'text-red-600' : 'text-blue-600'}`}>
             {formatTime(timeLeft)}
@@ -35,24 +38,35 @@ const QuestionSidebar = ({
       )}
 
       {/* Progress */}
-      <div className="mb-6">
-        <p className="text-sm text-gray-600 mb-2">
-          Progress: {answeredCount} / {totalItems}
-        </p>
+      <div className="mb-4">
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-sm text-gray-600">
+            {answeredCount} / {totalItems} answered
+          </p>
+          {flaggedCount > 0 && (
+            <span className="flex items-center gap-1 text-xs font-medium text-amber-700 bg-amber-50 px-2 py-0.5 rounded-full">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" fill="none" />
+              </svg>
+              {flaggedCount} flagged
+            </span>
+          )}
+        </div>
         <div className="w-full bg-gray-200 rounded-full h-2">
           <div
             className="bg-blue-600 h-2 rounded-full transition-all"
-            style={{ width: `${(answeredCount / totalItems) * 100}%` }}
+            style={{ width: `${totalItems > 0 ? (answeredCount / totalItems) * 100 : 0}%` }}
           />
         </div>
       </div>
 
       {/* Question List */}
-      <div className="space-y-2">
+      <div className="space-y-2 flex-1 overflow-y-auto min-h-0">
         <p className="text-xs font-medium text-gray-500 uppercase mb-2">Questions</p>
         {assessment.questions.map((q, index) => {
           const isStructured = q.questionType === 'STRUCTURED_WITH_PARTS' && q.parts && q.parts.length > 0;
           const isCurrent = index === currentQuestionIndex;
+          const isFlagged = flaggedQuestions.has(index);
 
           let isAnswered;
           if (isStructured) {
@@ -71,6 +85,8 @@ const QuestionSidebar = ({
                 className={`w-full text-left p-3 rounded-lg border transition-all ${
                   isCurrent
                     ? 'bg-blue-600 text-white border-blue-600'
+                    : isFlagged
+                    ? 'bg-amber-50 border-amber-300 text-amber-900 hover:bg-amber-100'
                     : isAnswered
                     ? 'bg-green-50 border-green-300 text-green-900 hover:bg-green-100'
                     : 'bg-white border-gray-200 hover:bg-gray-50'
@@ -78,11 +94,29 @@ const QuestionSidebar = ({
               >
                 <div className="flex items-center justify-between">
                   <span className="font-medium">Question {q.questionNumber}</span>
-                  {isAnswered && !isCurrent && (
-                    <svg className="w-5 h-5 text-green-600" fill="currentColor" viewBox="0 0 20 20">
-                      <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                    </svg>
-                  )}
+                  <div className="flex items-center gap-1.5">
+                    {isFlagged && !isCurrent && (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); onToggleFlag?.(index); }}
+                        title="Remove flag"
+                        className="text-amber-600 hover:text-amber-800"
+                      >
+                        <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" stroke="currentColor" fill="none" />
+                        </svg>
+                      </button>
+                    )}
+                    {isAnswered && !isCurrent && !isFlagged && (
+                      <svg className="w-5 h-5 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                      </svg>
+                    )}
+                    {isAnswered && isFlagged && !isCurrent && (
+                      <svg className="w-4 h-4 text-green-600" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                      </svg>
+                    )}
+                  </div>
                 </div>
                 {q.maxMarks && (
                   <p className={`text-xs mt-1 ${isCurrent ? 'text-blue-100' : 'text-gray-500'}`}>
@@ -94,6 +128,9 @@ const QuestionSidebar = ({
                     {q.parts.length} parts (a-{String.fromCharCode(96 + q.parts.length)})
                   </p>
                 )}
+                {isFlagged && !isCurrent && (
+                  <p className="text-xs mt-1 text-amber-600 font-medium">Review later</p>
+                )}
               </button>
             </div>
           );
@@ -101,17 +138,19 @@ const QuestionSidebar = ({
       </div>
 
       {/* Submit Button */}
-      <button
-        onClick={onSubmit}
-        disabled={submitting}
-        className="w-full mt-6 bg-gradient-to-r from-green-600 to-blue-600 text-white py-3 rounded-lg font-medium hover:from-green-700 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {submitting ? 'Submitting...' : 'Submit Assessment'}
-      </button>
+      <div className="mt-4 pt-4 border-t border-gray-200">
+        <button
+          onClick={onSubmit}
+          disabled={submitting}
+          className="w-full bg-gradient-to-r from-green-600 to-blue-600 text-white py-3 rounded-lg font-medium hover:from-green-700 hover:to-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {submitting ? 'Submitting...' : 'Submit Assessment'}
+        </button>
 
-      {isSaving && (
-        <p className="text-xs text-gray-500 text-center mt-2">Auto-saving...</p>
-      )}
+        {isSaving && (
+          <p className="text-xs text-gray-500 text-center mt-2">Auto-saving...</p>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/StudentMathKeyboard.js
+++ b/src/components/StudentMathKeyboard.js
@@ -179,17 +179,10 @@ const StudentMathKeyboard = ({ onInsert, onClose, compact = false }) => {
     setRecentSymbols(newRecent);
   };
 
-  const handleInsert = (symbol) => {
-    addToRecent(symbol);
-    onInsert(symbol);
-  };
-
   const handleInsertSymbol = (symbol) => {
-    if (symbol.latex) {
-      handleInsert(`$${symbol.value}$`, symbol.cursor);
-    } else {
-      handleInsert(symbol.value, symbol.cursor);
-    }
+    addToRecent(symbol);
+    const textValue = symbol.latex ? `$${symbol.value}$` : symbol.value;
+    onInsert(textValue, symbol.cursor);
   };
 
   const tabs = [
@@ -238,6 +231,7 @@ const StudentMathKeyboard = ({ onInsert, onClose, compact = false }) => {
           {mathSymbols.algebra.slice(0, 12).map((symbol, index) => (
             <button
               key={index}
+              onMouseDown={(e) => e.preventDefault()}
               onClick={() => handleInsertSymbol(symbol)}
               className="px-2 py-2 bg-gray-50 hover:bg-blue-50 rounded text-sm font-medium transition-colors"
               title={symbol.tooltip || symbol.value}
@@ -276,13 +270,14 @@ const StudentMathKeyboard = ({ onInsert, onClose, compact = false }) => {
         </button>
       </div>
 
-      {/* Tabs */}
-      <div className="flex border-b bg-gray-50">
+      {/* Tabs — horizontally scrollable so all tabs are reachable in a narrow panel */}
+      <div className="flex border-b bg-gray-50 overflow-x-auto">
         {tabs.map((tab) => (
           <button
             key={tab.id}
+            onMouseDown={(e) => e.preventDefault()}
             onClick={() => setActiveTab(tab.id)}
-            className={`flex-1 px-3 py-2 text-sm font-medium border-b-2 ${
+            className={`shrink-0 px-3 py-2 text-sm font-medium border-b-2 whitespace-nowrap ${
               activeTab === tab.id
                 ? "border-blue-600 text-blue-600 bg-white"
                 : "border-transparent text-gray-600 hover:text-blue-600"
@@ -305,6 +300,7 @@ const StudentMathKeyboard = ({ onInsert, onClose, compact = false }) => {
           )?.map((symbol, index) => (
             <button
               key={index}
+              onMouseDown={(e) => e.preventDefault()}
               onClick={() => handleInsertSymbol(symbol)}
               className="px-3 py-2 bg-gray-50 hover:bg-blue-50 rounded font-medium transition-colors text-center relative group"
               title={symbol.tooltip || symbol.value}

--- a/src/components/TeacherPages.js
+++ b/src/components/TeacherPages.js
@@ -167,6 +167,16 @@ export const AssessmentsPage = ({ user }) => {
     }
   };
 
+  const handleDeleteAssessment = async (id, title) => {
+    if (!window.confirm(`Permanently delete "${title}"?\n\nThis will also remove all student attempts and cannot be undone.`)) return;
+    try {
+      await axios.delete(`${API}/teacher/assessments/${id}`);
+      loadData();
+    } catch (error) {
+      handleApiError(error, "Failed to delete assessment");
+    }
+  };
+
   const getStatusBadge = (status) => {
     const labels = {
       draft: 'Draft',
@@ -725,6 +735,7 @@ export const AssessmentsPage = ({ user }) => {
                               onEdit={() => navigate(`/teacher/assessments/${a.id}/edit`)}
                               onViewSubmissions={() => navigate(`/teacher/assessments/${a.id}`)}
                               onViewEnhanced={() => navigate(`/teacher/assessments/${a.id}/enhanced`)}
+                              onDelete={a.status !== 'started' ? () => handleDeleteAssessment(a.id, a.title || question?.topic || 'this assessment') : undefined}
                             />
                           );
                         })}

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -37,6 +37,8 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     shuffleOptions: false,
     allowDraftSaving: true,
     markingStrictness: 'STANDARD_STRICT',
+    calculatorAllowed: false,
+    mathKeyboardEnabled: false,
     questions: [],
     class_id: null
   });
@@ -336,7 +338,11 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     runSave(
       async () => {
         if (isEdit) {
-          await axios.put(`${API}/teacher/assessments/${assessmentId}/questions`, assessmentData.questions);
+          await axios.put(`${API}/teacher/assessments/${assessmentId}/questions`, {
+            questions: assessmentData.questions,
+            calculatorAllowed: assessmentData.calculatorAllowed,
+            mathKeyboardEnabled: assessmentData.mathKeyboardEnabled,
+          });
           // For OCR assessments being re-saved after edits, ocrConfirmed stays as-is
           showNotification('Draft saved successfully!', 'success');
         } else {
@@ -372,7 +378,11 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
           const response = await axios.post(`${API}/teacher/assessments/enhanced`, payload);
           finalAssessmentId = response.data.assessment.id;
         } else {
-          await axios.put(`${API}/teacher/assessments/${assessmentId}/questions`, assessmentData.questions);
+          await axios.put(`${API}/teacher/assessments/${assessmentId}/questions`, {
+            questions: assessmentData.questions,
+            calculatorAllowed: assessmentData.calculatorAllowed,
+            mathKeyboardEnabled: assessmentData.mathKeyboardEnabled,
+          });
         }
 
         await axios.post(`${API}/teacher/assessments/${finalAssessmentId}/publish`);
@@ -568,6 +578,31 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               />
             </div>
 
+            <div>
+              <p className="text-sm font-medium text-gray-700 mb-2">Student tools</p>
+              <div className="flex flex-wrap gap-4">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={assessmentData.calculatorAllowed}
+                    onChange={(e) => updateField('calculatorAllowed', e.target.checked)}
+                    className="rounded"
+                  />
+                  <span className="text-sm">Calculator</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={assessmentData.mathKeyboardEnabled}
+                    onChange={(e) => updateField('mathKeyboardEnabled', e.target.checked)}
+                    className="rounded"
+                  />
+                  <span className="text-sm">Maths keyboard</span>
+                </label>
+              </div>
+              <p className="text-xs text-gray-400 mt-1">Enabled tools appear as toggle buttons on the right side of the student's screen during the assessment.</p>
+            </div>
+
             <div className="flex justify-between pt-4 border-t">
               <button onClick={() => setCurrentStep(1)} className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50">← Back</button>
               <button
@@ -696,7 +731,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               </div>
             )}
 
-            <div className="flex gap-4">
+            <div className="flex flex-wrap gap-4">
               <label className="flex items-center gap-2">
                 <input
                   type="checkbox"
@@ -716,6 +751,31 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                 />
                 <span className="text-sm">Shuffle MCQ options</span>
               </label>
+            </div>
+
+            <div>
+              <p className="text-sm font-medium text-gray-700 mb-2">Student tools</p>
+              <div className="flex flex-wrap gap-4">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={assessmentData.calculatorAllowed}
+                    onChange={(e) => updateField('calculatorAllowed', e.target.checked)}
+                    className="rounded"
+                  />
+                  <span className="text-sm">Calculator</span>
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={assessmentData.mathKeyboardEnabled}
+                    onChange={(e) => updateField('mathKeyboardEnabled', e.target.checked)}
+                    className="rounded"
+                  />
+                  <span className="text-sm">Maths keyboard</span>
+                </label>
+              </div>
+              <p className="text-xs text-gray-400 mt-1">Enabled tools appear as toggle buttons on the right side of the student's screen during the assessment.</p>
             </div>
 
             <div className="flex justify-between pt-4 border-t">

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -56,6 +56,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   const [extractionSummary, setExtractionSummary] = useState(null);
   const [pageThumbnails, setPageThumbnails] = useState({});
   const [pageImages, setPageImages] = useState({});
+  const [msPageThumbnails, setMsPageThumbnails] = useState({});
 
   const OCR_GCSE_MODE = 'OCR_GENERATED_GCSE_PAST_PAPER';
 
@@ -122,6 +123,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
       setExtractionSummary(response.data.extraction_summary || null);
       setPageThumbnails(response.data.page_thumbnails || {});
       setPageImages(response.data.page_images || {});
+      setMsPageThumbnails(response.data.ms_page_thumbnails || {});
       setOcrReviewState('reviewing');
       showNotification(
         `${questions.length} question${questions.length !== 1 ? 's' : ''} extracted — please review before confirming`,
@@ -149,6 +151,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     setExtractionSummary(null);
     setPageThumbnails({});
     setPageImages({});
+    setMsPageThumbnails({});
     setOcrReviewState('uploading');
   }, []);
 
@@ -871,6 +874,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
                   questions={assessmentData.questions}
                   pageThumbnails={pageThumbnails}
                   pageImages={pageImages}
+                  msPageThumbnails={msPageThumbnails}
                   onConfirm={handleOcrReviewConfirm}
                   onBack={handleOcrReviewBack}
                 />
@@ -937,22 +941,25 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               </div>
             )}
 
-            <div className="bg-white rounded-lg shadow p-6 flex justify-between items-center sticky bottom-0">
-              <button
-                onClick={saveDraft}
-                disabled={saving}
-                className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
-              >
-                {saving ? 'Saving...' : '💾 Save Draft'}
-              </button>
-              <button
-                onClick={handlePublishClick}
-                disabled={saving}
-                className="px-6 py-3 bg-gradient-to-r from-green-600 to-blue-600 text-white rounded-lg hover:from-green-700 hover:to-blue-700 font-medium disabled:opacity-50"
-              >
-                {saving ? 'Publishing...' : '🚀 Publish Assessment'}
-              </button>
-            </div>
+            {/* Hide Save/Publish while the OCR review is in progress — teacher must complete review first */}
+            {(assessmentData.assessmentMode !== OCR_GCSE_MODE || ocrReviewState === 'editing') && (
+              <div className="bg-white rounded-lg shadow p-6 flex justify-between items-center sticky bottom-0">
+                <button
+                  onClick={saveDraft}
+                  disabled={saving}
+                  className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                >
+                  {saving ? 'Saving...' : '💾 Save Draft'}
+                </button>
+                <button
+                  onClick={handlePublishClick}
+                  disabled={saving}
+                  className="px-6 py-3 bg-gradient-to-r from-green-600 to-blue-600 text-white rounded-lg hover:from-green-700 hover:to-blue-700 font-medium disabled:opacity-50"
+                >
+                  {saving ? 'Publishing...' : '🚀 Publish Assessment'}
+                </button>
+              </div>
+            )}
           </>
         )}
       </div>

--- a/src/pages/EnhancedAssessmentDetailPage.js
+++ b/src/pages/EnhancedAssessmentDetailPage.js
@@ -12,6 +12,11 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState(null);
   const [releasingIds, setReleasingIds] = useState(new Set());
+  const [showAssignModal, setShowAssignModal] = useState(false);
+  const [classes, setClasses] = useState([]);
+  const [selectedClassId, setSelectedClassId] = useState('');
+  const [assigning, setAssigning] = useState(false);
+  const [assignResult, setAssignResult] = useState(null);
 
   useEffect(() => {
     loadData();
@@ -106,6 +111,30 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
   const isOcrLocked = assessment.assessmentMode === 'OCR_GENERATED_GCSE_PAST_PAPER' && assessment.ocrConfirmed;
   const unreleasedCount = submissions?.filter(s => s.status === 'marked' && !s.feedback_released).length || 0;
 
+  const openAssignModal = async () => {
+    setAssignResult(null);
+    setSelectedClassId('');
+    setShowAssignModal(true);
+    try {
+      const res = await axios.get(`${API}/teacher/classes`);
+      setClasses(res.data.classes || []);
+    } catch {
+      setClasses([]);
+    }
+  };
+
+  const handleAssign = async () => {
+    if (!selectedClassId) return;
+    setAssigning(true);
+    try {
+      const res = await axios.post(`${API}/teacher/assessments/${assessmentId}/assignments`, { class_id: selectedClassId });
+      setAssignResult(res.data);
+    } catch (error) {
+      handleApiError(error, 'Failed to assign assessment');
+    }
+    setAssigning(false);
+  };
+
   const handleUnlockOcr = async () => {
     if (!window.confirm(
       'Unlock this GCSE Past Paper assessment for re-extraction?\n\n' +
@@ -153,6 +182,17 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
                   <p><strong>Submissions:</strong> {attempts_count}</p>
                 </div>
               </div>
+            </div>
+            <div className="ml-4 shrink-0">
+              <button
+                onClick={openAssignModal}
+                className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+                </svg>
+                Assign to Class
+              </button>
             </div>
           </div>
 
@@ -287,6 +327,82 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
           )}
         </div>
       </div>
+
+      {/* Assign to Class Modal */}
+      {showAssignModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-xl max-w-md w-full">
+            <div className="p-6 border-b flex justify-between items-center">
+              <h2 className="text-xl font-bold text-gray-900">Assign to Class</h2>
+              <button onClick={() => { setShowAssignModal(false); setAssignResult(null); }} className="text-gray-500 hover:text-gray-700">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="p-6 space-y-4">
+              {assignResult ? (
+                <div className="text-center space-y-3">
+                  <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto">
+                    <svg className="w-6 h-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                  </div>
+                  <p className="font-semibold text-gray-900">Assigned to {assignResult.class_name}!</p>
+                  <div className="bg-blue-50 rounded-lg p-4">
+                    <p className="text-xs text-gray-500 mb-1">Student join code</p>
+                    <p className="text-3xl font-mono font-bold text-blue-700 tracking-widest">{assignResult.assignment.join_code}</p>
+                    <p className="text-xs text-gray-500 mt-2">Share this code with students in {assignResult.class_name}.</p>
+                  </div>
+                  <button
+                    onClick={() => { setShowAssignModal(false); setAssignResult(null); }}
+                    className="w-full bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700"
+                  >
+                    Done
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Select Class</label>
+                    {classes.length === 0 ? (
+                      <p className="text-sm text-gray-500">No classes found. Create a class first.</p>
+                    ) : (
+                      <select
+                        value={selectedClassId}
+                        onChange={e => setSelectedClassId(e.target.value)}
+                        className="w-full border rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500"
+                      >
+                        <option value="">-- Select a class --</option>
+                        {classes.map(c => (
+                          <option key={c.id} value={c.id}>
+                            {c.class_name}{c.year_group ? ` (Year ${c.year_group})` : ''}
+                          </option>
+                        ))}
+                      </select>
+                    )}
+                  </div>
+                  <div className="flex gap-3 pt-2">
+                    <button
+                      onClick={() => { setShowAssignModal(false); setAssignResult(null); }}
+                      className="flex-1 bg-gray-100 text-gray-700 py-2 rounded-lg hover:bg-gray-200"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={handleAssign}
+                      disabled={!selectedClassId || assigning}
+                      className="flex-1 bg-blue-600 text-white py-2 rounded-lg hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      {assigning ? 'Assigning...' : 'Assign & Generate Code'}
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/EnhancedAttemptPage.js
+++ b/src/pages/EnhancedAttemptPage.js
@@ -4,6 +4,8 @@ import axios from 'axios';
 import StudentMathInput from '../components/StudentMathInput';
 import LaTeXRenderer from '../components/LaTeXRenderer';
 import DiagramRenderer from '../components/DiagramRenderer';
+import DrawableCanvas, { requiresDrawing } from '../components/DrawableCanvas';
+import StudentMathKeyboard from '../components/StudentMathKeyboard';
 import EnhancedFeedbackView from '../components/EnhancedFeedbackView';
 import QuestionSidebar from '../components/QuestionSidebar';
 import SecurityOverlays from '../components/SecurityOverlays';
@@ -24,6 +26,7 @@ export const EnhancedAttemptPage = () => {
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [answers, setAnswers] = useState({});
   const [showSubmitConfirm, setShowSubmitConfirm] = useState(false);
+  const [showMathKeyboard, setShowMathKeyboard] = useState(false);
 
   const { timeLeft } = useTimer({
     // Per-student timing: count down from when the student personally joined.
@@ -141,6 +144,17 @@ export const EnhancedAttemptPage = () => {
     setCurrentQuestionIndex(prev => prev > 0 ? prev - 1 : prev);
   }, []);
 
+  // Returns true if an answer value (string or drawing JSON) counts as answered.
+  const hasAnswer = useCallback((val) => {
+    if (!val) return false;
+    try {
+      const parsed = JSON.parse(val);
+      return parsed?._type === 'drawing' && !!parsed.imageData;
+    } catch {
+      return !!val.trim();
+    }
+  }, []);
+
   const answerProgress = useMemo(() => {
     if (!assessment?.questions) return { answeredCount: 0, totalItems: 0 };
     let answeredCount = 0;
@@ -150,15 +164,15 @@ export const EnhancedAttemptPage = () => {
         totalItems += q.parts.length;
         q.parts.forEach(part => {
           const partKey = `${q.questionNumber}-${part.partLabel}`;
-          if (answers[partKey]?.trim()) answeredCount++;
+          if (hasAnswer(answers[partKey])) answeredCount++;
         });
       } else {
         totalItems += 1;
-        if (answers[q.questionNumber]?.trim()) answeredCount++;
+        if (hasAnswer(answers[q.questionNumber])) answeredCount++;
       }
     });
     return { answeredCount, totalItems };
-  }, [assessment?.questions, answers]);
+  }, [assessment?.questions, answers, hasAnswer]);
 
   if (loading) {
     return (
@@ -231,6 +245,35 @@ export const EnhancedAttemptPage = () => {
 
   const isFormative = assessment.assessmentMode === 'FORMATIVE_SINGLE_LONG_RESPONSE';
 
+  // Respect explicit teacher override; fall back to keyword auto-detection.
+  const shouldDraw = (entity, text) => {
+    if (entity?.drawingEnabled === true) return true;
+    if (entity?.drawingEnabled === false) return false;
+    return requiresDrawing(text);
+  };
+
+  // Insert a keyboard symbol into whichever textarea/input is currently focused.
+  const insertIntoFocused = (symbol, cursorOffset = 0) => {
+    const el = document.activeElement;
+    if (!el || (el.tagName !== 'TEXTAREA' && el.tagName !== 'INPUT')) return;
+    const start = el.selectionStart ?? el.value.length;
+    const end = el.selectionEnd ?? el.value.length;
+    const before = el.value.substring(0, start);
+    const after = el.value.substring(end);
+    const newValue = before + symbol + after;
+    // Trigger React's synthetic onChange via the native value setter.
+    const proto = el.tagName === 'TEXTAREA'
+      ? window.HTMLTextAreaElement.prototype
+      : window.HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(proto, 'value').set.call(el, newValue);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    setTimeout(() => {
+      const pos = start + symbol.length + (cursorOffset || 0);
+      el.focus();
+      el.setSelectionRange(pos, pos);
+    }, 0);
+  };
+
   return (
     <div
       className="min-h-screen bg-gray-50 flex"
@@ -292,6 +335,15 @@ export const EnhancedAttemptPage = () => {
               <div className="mt-6 space-y-6">
                 {currentQuestion.parts.map((part, idx) => {
                   const partAnswerKey = `${currentQuestion.questionNumber}-${part.partLabel}`;
+                  const partNeedsDrawing = shouldDraw(part, part.partPrompt);
+                  // Recover saved drawing data if any
+                  let savedDrawingData = null;
+                  if (partNeedsDrawing && answers[partAnswerKey]) {
+                    try {
+                      const p = JSON.parse(answers[partAnswerKey]);
+                      if (p?._type === 'drawing') savedDrawingData = p.imageData;
+                    } catch { /* not a drawing answer */ }
+                  }
                   return (
                     <div key={idx} className="border-l-4 border-blue-500 pl-4 py-2">
                       <div className="flex items-start justify-between mb-3">
@@ -301,6 +353,11 @@ export const EnhancedAttemptPage = () => {
                             <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs font-medium">
                               {part.maxMarks} {part.maxMarks === 1 ? 'mark' : 'marks'}
                             </span>
+                            {partNeedsDrawing && (
+                              <span className="px-2 py-1 bg-purple-100 text-purple-800 rounded text-xs font-medium">
+                                Draw / Plot
+                              </span>
+                            )}
                           </div>
                           <div className="prose max-w-none">
                             <LaTeXRenderer text={part.partPrompt || ''} />
@@ -311,12 +368,22 @@ export const EnhancedAttemptPage = () => {
                         </div>
                       </div>
                       <div className="mt-3">
-                        <StudentMathInput
-                          value={answers[partAnswerKey] || ''}
-                          onChange={(value) => handleAnswerChange(partAnswerKey, value)}
-                          placeholder={`Your answer for part ${part.partLabel}...`}
-                          showKeyboard={false}
-                        />
+                        {partNeedsDrawing ? (
+                          <DrawableCanvas
+                            key={partAnswerKey}
+                            initialDrawing={savedDrawingData}
+                            onChange={(imageData) =>
+                              handleAnswerChange(partAnswerKey, JSON.stringify({ _type: 'drawing', imageData }))
+                            }
+                          />
+                        ) : (
+                          <StudentMathInput
+                            value={answers[partAnswerKey] || ''}
+                            onChange={(value) => handleAnswerChange(partAnswerKey, value)}
+                            placeholder={`Your answer for part ${part.partLabel}...`}
+                            showKeyboard={false}
+                          />
+                        )}
                       </div>
                     </div>
                   );
@@ -356,20 +423,84 @@ export const EnhancedAttemptPage = () => {
 
           {/* Answer Input for non-MCQ and non-Structured */}
           {currentQuestion.questionType !== 'MULTIPLE_CHOICE' &&
-           currentQuestion.questionType !== 'STRUCTURED_WITH_PARTS' && (
-            <div className="bg-white rounded-lg shadow-sm p-6">
-              <h3 className="text-lg font-medium text-gray-900 mb-4">Your Answer</h3>
-              <StudentMathInput
-                value={answers[currentQuestion.questionNumber] || ''}
-                onChange={(value) => handleAnswerChange(currentQuestion.questionNumber, value)}
-                placeholder="Type your answer here..."
-                showKeyboard={true}
-              />
-              <p className="text-sm text-gray-500 mt-2">
-                You can use the math keyboard to insert mathematical symbols and expressions.
-              </p>
+           currentQuestion.questionType !== 'STRUCTURED_WITH_PARTS' && (() => {
+            const needsDrawing = shouldDraw(currentQuestion, currentQuestion.questionBody);
+            let savedDrawing = null;
+            if (needsDrawing && answers[currentQuestion.questionNumber]) {
+              try {
+                const p = JSON.parse(answers[currentQuestion.questionNumber]);
+                if (p?._type === 'drawing') savedDrawing = p.imageData;
+              } catch { /* not a drawing answer */ }
+            }
+            return (
+              <div className="bg-white rounded-lg shadow-sm p-6">
+                <h3 className="text-lg font-medium text-gray-900 mb-4 flex items-center gap-2">
+                  Your Answer
+                  {needsDrawing && (
+                    <span className="px-2 py-0.5 bg-purple-100 text-purple-800 rounded text-xs font-medium">
+                      Draw / Plot
+                    </span>
+                  )}
+                </h3>
+                {needsDrawing ? (
+                  <DrawableCanvas
+                    key={currentQuestion.questionNumber}
+                    initialDrawing={savedDrawing}
+                    onChange={(imageData) =>
+                      handleAnswerChange(currentQuestion.questionNumber, JSON.stringify({ _type: 'drawing', imageData }))
+                    }
+                  />
+                ) : (
+                  <>
+                    <StudentMathInput
+                      value={answers[currentQuestion.questionNumber] || ''}
+                      onChange={(value) => handleAnswerChange(currentQuestion.questionNumber, value)}
+                      placeholder="Type your answer here..."
+                      showKeyboard={true}
+                    />
+                    <p className="text-sm text-gray-500 mt-2">
+                      You can use the math keyboard to insert mathematical symbols and expressions.
+                    </p>
+                  </>
+                )}
+              </div>
+            );
+          })()}
+
+          {/* Floating maths keyboard panel (right side, teacher-enabled per question) */}
+      {currentQuestion.mathKeyboardEnabled && (
+        <>
+          {/* Toggle button — visible when panel is closed */}
+          {!showMathKeyboard && (
+            <button
+              onClick={() => setShowMathKeyboard(true)}
+              className="fixed right-4 bottom-24 z-40 flex items-center gap-2 px-4 py-2.5 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 text-sm font-medium"
+              title="Open maths keyboard"
+            >
+              🔢 Keyboard
+            </button>
+          )}
+          {/* Panel */}
+          {showMathKeyboard && (
+            <div className="fixed right-0 top-0 h-full w-72 bg-white shadow-2xl border-l border-gray-200 overflow-y-auto z-40 flex flex-col">
+              <div className="flex items-center justify-between px-4 py-3 border-b bg-blue-600 text-white shrink-0">
+                <span className="font-semibold text-sm">🔢 Maths Keyboard</span>
+                <button
+                  onClick={() => setShowMathKeyboard(false)}
+                  className="p-1 rounded hover:bg-blue-700 text-white"
+                  title="Close keyboard"
+                >✕</button>
+              </div>
+              <div className="flex-1 overflow-y-auto p-2">
+                <StudentMathKeyboard
+                  onInsert={insertIntoFocused}
+                  onClose={() => setShowMathKeyboard(false)}
+                />
+              </div>
             </div>
           )}
+        </>
+      )}
 
           {/* Navigation Buttons */}
           <div className="flex justify-between mt-8">

--- a/src/pages/EnhancedAttemptPage.js
+++ b/src/pages/EnhancedAttemptPage.js
@@ -1,11 +1,11 @@
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import StudentMathInput from '../components/StudentMathInput';
 import LaTeXRenderer from '../components/LaTeXRenderer';
 import DiagramRenderer from '../components/DiagramRenderer';
 import DrawableCanvas, { requiresDrawing } from '../components/DrawableCanvas';
 import StudentMathKeyboard from '../components/StudentMathKeyboard';
+import StudentCalculator from '../components/StudentCalculator';
 import EnhancedFeedbackView from '../components/EnhancedFeedbackView';
 import QuestionSidebar from '../components/QuestionSidebar';
 import SecurityOverlays from '../components/SecurityOverlays';
@@ -27,6 +27,8 @@ export const EnhancedAttemptPage = () => {
   const [answers, setAnswers] = useState({});
   const [showSubmitConfirm, setShowSubmitConfirm] = useState(false);
   const [showMathKeyboard, setShowMathKeyboard] = useState(false);
+  const [showCalculator, setShowCalculator] = useState(false);
+  const [flaggedQuestions, setFlaggedQuestions] = useState(new Set());
 
   const { timeLeft } = useTimer({
     // Per-student timing: count down from when the student personally joined.
@@ -136,6 +138,15 @@ export const EnhancedAttemptPage = () => {
     }
   };
 
+  const toggleFlag = useCallback((index) => {
+    setFlaggedQuestions(prev => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  }, []);
+
   const goToQuestion = useCallback((index) => setCurrentQuestionIndex(index), []);
   const goToNextQuestion = useCallback(() => {
     setCurrentQuestionIndex(prev => prev < (assessment?.questions?.length || 1) - 1 ? prev + 1 : prev);
@@ -173,6 +184,20 @@ export const EnhancedAttemptPage = () => {
     });
     return { answeredCount, totalItems };
   }, [assessment?.questions, answers, hasAnswer]);
+
+  // Track the last focused textarea/input so the keyboard can insert even after
+  // focus moves to a keyboard button (onMouseDown prevents this in most cases,
+  // but the ref is a reliable fallback).
+  const lastFocusedInputRef = useRef(null);
+  useEffect(() => {
+    const track = (e) => {
+      if (e.target.tagName === 'TEXTAREA' || e.target.tagName === 'INPUT') {
+        lastFocusedInputRef.current = e.target;
+      }
+    };
+    document.addEventListener('focusin', track);
+    return () => document.removeEventListener('focusin', track);
+  }, []);
 
   if (loading) {
     return (
@@ -252,9 +277,9 @@ export const EnhancedAttemptPage = () => {
     return requiresDrawing(text);
   };
 
-  // Insert a keyboard symbol into whichever textarea/input is currently focused.
+  // Insert a keyboard symbol into the last focused textarea/input.
   const insertIntoFocused = (symbol, cursorOffset = 0) => {
-    const el = document.activeElement;
+    const el = lastFocusedInputRef.current || document.activeElement;
     if (!el || (el.tagName !== 'TEXTAREA' && el.tagName !== 'INPUT')) return;
     const start = el.selectionStart ?? el.value.length;
     const end = el.selectionEnd ?? el.value.length;
@@ -276,7 +301,7 @@ export const EnhancedAttemptPage = () => {
 
   return (
     <div
-      className="min-h-screen bg-gray-50 flex"
+      className="h-screen overflow-hidden bg-gray-50 flex"
       onCopy={(e) => e.preventDefault()}
       onCut={(e) => e.preventDefault()}
       onContextMenu={(e) => e.preventDefault()}
@@ -293,7 +318,9 @@ export const EnhancedAttemptPage = () => {
         timeLeft={timeLeft}
         answers={answers}
         currentQuestionIndex={currentQuestionIndex}
+        flaggedQuestions={flaggedQuestions}
         onGoToQuestion={goToQuestion}
+        onToggleFlag={toggleFlag}
         onSubmit={() => handleSubmit(false)}
         submitting={submitting}
         isSaving={isSaving}
@@ -308,17 +335,26 @@ export const EnhancedAttemptPage = () => {
               <h2 className="text-2xl font-bold text-gray-900">
                 Question {currentQuestion.questionNumber}
               </h2>
-              <div className="flex items-center gap-4">
+              <div className="flex items-center gap-3">
                 {currentQuestion.maxMarks && !isFormative && (
                   <span className="px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-medium">
                     {currentQuestion.maxMarks} marks
                   </span>
                 )}
-                {currentQuestion.calculatorAllowed && (
-                  <span className="px-3 py-1 bg-purple-100 text-purple-800 rounded-full text-sm font-medium">
-                    Calculator Allowed
-                  </span>
-                )}
+                <button
+                  onClick={() => toggleFlag(currentQuestionIndex)}
+                  title={flaggedQuestions.has(currentQuestionIndex) ? 'Remove flag' : 'Flag for review'}
+                  className={`flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                    flaggedQuestions.has(currentQuestionIndex)
+                      ? 'bg-amber-100 text-amber-700 hover:bg-amber-200'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                  }`}
+                >
+                  <svg className="w-4 h-4" fill={flaggedQuestions.has(currentQuestionIndex) ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9" />
+                  </svg>
+                  {flaggedQuestions.has(currentQuestionIndex) ? 'Flagged' : 'Flag'}
+                </button>
               </div>
             </div>
 
@@ -329,6 +365,34 @@ export const EnhancedAttemptPage = () => {
             {currentQuestion.stimulusBlock && (
               <DiagramRenderer diagram={currentQuestion.stimulusBlock} className="mt-2" />
             )}
+
+            {/* Question-level drawing canvas for structured questions whose body requires a sketch */}
+            {currentQuestion.questionType === 'STRUCTURED_WITH_PARTS' && (() => {
+              const qNeedsDrawing = shouldDraw(currentQuestion, currentQuestion.questionBody);
+              if (!qNeedsDrawing) return null;
+              const sketchKey = `${currentQuestion.questionNumber}-drawing`;
+              let savedSketch = null;
+              if (answers[sketchKey]) {
+                try {
+                  const p = JSON.parse(answers[sketchKey]);
+                  if (p?._type === 'drawing') savedSketch = p.imageData;
+                } catch { /* not a drawing answer */ }
+              }
+              return (
+                <div className="mt-4 border border-purple-200 bg-purple-50 rounded-lg p-4">
+                  <p className="text-sm font-medium text-purple-800 mb-3">
+                    Use the grid below to sketch your answer
+                  </p>
+                  <DrawableCanvas
+                    key={sketchKey}
+                    initialDrawing={savedSketch}
+                    onChange={(imageData) =>
+                      handleAnswerChange(sketchKey, JSON.stringify({ _type: 'drawing', imageData }))
+                    }
+                  />
+                </div>
+              );
+            })()}
 
             {/* Structured Question Parts */}
             {currentQuestion.questionType === 'STRUCTURED_WITH_PARTS' && currentQuestion.parts && currentQuestion.parts.length > 0 && (
@@ -377,12 +441,21 @@ export const EnhancedAttemptPage = () => {
                             }
                           />
                         ) : (
-                          <StudentMathInput
-                            value={answers[partAnswerKey] || ''}
-                            onChange={(value) => handleAnswerChange(partAnswerKey, value)}
-                            placeholder={`Your answer for part ${part.partLabel}...`}
-                            showKeyboard={false}
-                          />
+                          <div className="space-y-2">
+                            <textarea
+                              value={answers[partAnswerKey] || ''}
+                              onChange={(e) => handleAnswerChange(partAnswerKey, e.target.value)}
+                              placeholder={`Your answer for part ${part.partLabel}...`}
+                              rows={3}
+                              className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none resize-none"
+                            />
+                            {answers[partAnswerKey]?.includes('$') && (
+                              <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                                <p className="text-xs text-blue-600 font-medium mb-1">Rendered preview</p>
+                                <LaTeXRenderer text={answers[partAnswerKey]} />
+                              </div>
+                            )}
+                          </div>
                         )}
                       </div>
                     </div>
@@ -451,56 +524,79 @@ export const EnhancedAttemptPage = () => {
                     }
                   />
                 ) : (
-                  <>
-                    <StudentMathInput
+                  <div className="space-y-2">
+                    <textarea
                       value={answers[currentQuestion.questionNumber] || ''}
-                      onChange={(value) => handleAnswerChange(currentQuestion.questionNumber, value)}
+                      onChange={(e) => handleAnswerChange(currentQuestion.questionNumber, e.target.value)}
                       placeholder="Type your answer here..."
-                      showKeyboard={true}
+                      rows={4}
+                      className="w-full px-4 py-3 border-2 border-gray-300 rounded-lg focus:border-blue-500 focus:outline-none resize-none"
                     />
-                    <p className="text-sm text-gray-500 mt-2">
-                      You can use the math keyboard to insert mathematical symbols and expressions.
-                    </p>
-                  </>
+                    {answers[currentQuestion.questionNumber]?.includes('$') && (
+                      <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                        <p className="text-xs text-blue-600 font-medium mb-1">Rendered preview</p>
+                        <LaTeXRenderer text={answers[currentQuestion.questionNumber]} />
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
             );
           })()}
 
-          {/* Floating maths keyboard panel (right side, teacher-enabled per question) */}
-      {currentQuestion.mathKeyboardEnabled && (
-        <>
-          {/* Toggle button — visible when panel is closed */}
-          {!showMathKeyboard && (
-            <button
-              onClick={() => setShowMathKeyboard(true)}
-              className="fixed right-4 bottom-24 z-40 flex items-center gap-2 px-4 py-2.5 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 text-sm font-medium"
-              title="Open maths keyboard"
-            >
-              🔢 Keyboard
-            </button>
-          )}
-          {/* Panel */}
-          {showMathKeyboard && (
-            <div className="fixed right-0 top-0 h-full w-72 bg-white shadow-2xl border-l border-gray-200 overflow-y-auto z-40 flex flex-col">
+          {/* Assessment-wide tool panels */}
+          {assessment.mathKeyboardEnabled && showMathKeyboard && (
+            <div className="fixed right-0 top-0 h-full w-72 bg-white shadow-2xl border-l border-gray-200 z-40 flex flex-col">
               <div className="flex items-center justify-between px-4 py-3 border-b bg-blue-600 text-white shrink-0">
-                <span className="font-semibold text-sm">🔢 Maths Keyboard</span>
+                <span className="font-semibold text-sm">Maths Keyboard</span>
                 <button
                   onClick={() => setShowMathKeyboard(false)}
                   className="p-1 rounded hover:bg-blue-700 text-white"
-                  title="Close keyboard"
                 >✕</button>
               </div>
               <div className="flex-1 overflow-y-auto p-2">
-                <StudentMathKeyboard
-                  onInsert={insertIntoFocused}
-                  onClose={() => setShowMathKeyboard(false)}
-                />
+                <StudentMathKeyboard onInsert={insertIntoFocused} onClose={() => setShowMathKeyboard(false)} />
               </div>
             </div>
           )}
-        </>
-      )}
+
+          {assessment.calculatorAllowed && showCalculator && (
+            <div className={`fixed ${showMathKeyboard ? 'right-[19rem]' : 'right-4'} bottom-28 z-40 w-80 transition-all duration-200`}>
+              <StudentCalculator onClose={() => setShowCalculator(false)} />
+            </div>
+          )}
+
+          {/* Floating tool toggle buttons (assessment-wide) */}
+          {(assessment.calculatorAllowed || assessment.mathKeyboardEnabled) && (
+            <div className={`fixed ${showMathKeyboard ? 'right-[19rem]' : 'right-4'} bottom-8 flex flex-col gap-2 z-50 transition-all duration-200`}>
+              {assessment.calculatorAllowed && (
+                <button
+                  onClick={() => setShowCalculator(v => !v)}
+                  className={`flex items-center gap-2 px-4 py-2.5 rounded-full shadow-lg text-sm font-medium transition-colors ${
+                    showCalculator ? 'bg-purple-700 text-white hover:bg-purple-800' : 'bg-purple-600 text-white hover:bg-purple-700'
+                  }`}
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 7H7a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V9a2 2 0 00-2-2h-2M9 7V5a2 2 0 012-2h2a2 2 0 012 2v2M9 7h6M9 12h.01M12 12h.01M15 12h.01M9 16h.01M12 16h.01M15 16h.01" />
+                  </svg>
+                  Calculator
+                </button>
+              )}
+              {assessment.mathKeyboardEnabled && (
+                <button
+                  onClick={() => setShowMathKeyboard(v => !v)}
+                  className={`flex items-center gap-2 px-4 py-2.5 rounded-full shadow-lg text-sm font-medium transition-colors ${
+                    showMathKeyboard ? 'bg-blue-700 text-white hover:bg-blue-800' : 'bg-blue-600 text-white hover:bg-blue-700'
+                  }`}
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+                  </svg>
+                  Maths Keyboard
+                </button>
+              )}
+            </div>
+          )}
 
           {/* Navigation Buttons */}
           <div className="flex justify-between mt-8">

--- a/src/pages/JoinPage.js
+++ b/src/pages/JoinPage.js
@@ -19,7 +19,7 @@ export const JoinPage = () => {
   const [classRoster, setClassRoster] = useState(null);
   const [selectedStudentId, setSelectedStudentId] = useState('');
 
-  // Phase 4: Check if assessment is class-linked when join code changes
+  // Check if the code is an assignment code or class-linked assessment when entered
   const handleCodeChange = async (code) => {
     setJoinCode(code.toUpperCase());
     setClassRoster(null);
@@ -28,7 +28,8 @@ export const JoinPage = () => {
     setFirstName('');
     setLastName('');
     setCandidateNumber('');
-    
+    setError('');
+
     if (code.length === 6) {
       setCheckingCode(true);
       try {
@@ -36,8 +37,13 @@ export const JoinPage = () => {
         if (response.data.has_roster && response.data.students.length > 0) {
           setClassRoster(response.data);
         }
+        // type=assignment or has_roster=false → just show the manual name form (no action needed)
       } catch (err) {
-        // Silently fail - code might be invalid or not class-linked
+        // 400 means the code is valid but the assessment/assignment is closed
+        if (err.response?.status === 400) {
+          setError('This assessment is now closed. Contact your teacher.');
+        }
+        // 404 = invalid code — let the submit button validate it on submit
       }
       setCheckingCode(false);
     }
@@ -77,7 +83,14 @@ export const JoinPage = () => {
         navigate(`/attempt/${attemptId}`);
       }
     } catch (err) {
-      setError(getApiErrorMessage(err, 'Failed to join assessment'));
+      const msg = err.response?.data?.detail || '';
+      if (msg === 'Invalid join code') {
+        setError('Invalid join code. Please check the code and try again.');
+      } else if (msg === 'This assessment is now closed') {
+        setError('This assessment is now closed. Contact your teacher.');
+      } else {
+        setError(getApiErrorMessage(err, 'Failed to join assessment'));
+      }
       setLoading(false);
     }
   };


### PR DESCRIPTION
Added:
- freehand drawing canvas with grid background for sketch-based questions
- per-question flag for review during assessments with a flagged count and "Review later" indicator in the sidebar
- assessment-wide calculator and maths keyboard toggle buttons on the attempt page
- live maths preview beneath answer boxes when LaTeX symbols are typed
- drawing canvas at the question level for structured questions whose sketch instruction is in the main body rather than a sub-part
- class-assessment assignment system so teachers can assign an assessment to a class from either the class detail page or the assessment detail page, each with its own unique join code that can be opened, closed, and deleted independently
- assessment delete option in the assessments list
- mark scheme page thumbnails shown alongside each extracted question in the OCR review screen
- inline error on the join page when a closed assignment code is detected before the student submits.

Updated:
- Maths keyboard now correctly inserts symbols into the last focused answer box and the tab bar no longer requires horizontal scrolling
- calculator and maths keyboard settings moved from individual question settings to the assessment level, set once in Step 2 of the builder
- question sidebar list scrolls independently so the timer, progress bar and submit button always stay visible
- LaTeX renderer now handles `\(...\)` and `\[...\]` delimiter formats in addition to `$...$` and `$$...$$`
- assessment card overflow menu dropdown no longer clipped by the card container.

Removed:
- per-question calculator and maths keyboard checkboxes from the question editor
- `StudentMathInput` from the attempt page, replaced with a plain text box and a rendered preview.