### PR TITLE
[25] Updated frontend to link students' classes to assessments

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -25,6 +25,7 @@ const AdminDashboard = lazy(() => import('./components/AdminPages').then(m => ({
 const AnalyticsPage = lazy(() => import('./components/AnalyticsPage').then(m => ({ default: m.AnalyticsPage })));
 const ClassesPage = lazy(() => import('./components/ClassesPage').then(m => ({ default: m.ClassesPage })));
 const ClassDetailPage = lazy(() => import('./components/ClassesPage').then(m => ({ default: m.ClassDetailPage })));
+const StudentDetailPage = lazy(() => import('./components/ClassesPage').then(m => ({ default: m.StudentDetailPage })));
 const CSVImportPage = lazy(() => import('./components/CSVImportPage').then(m => ({ default: m.CSVImportPage })));
 const OCRUploadPage = lazy(() => import('./components/OCRUploadPage').then(m => ({ default: m.default || m.OCRUploadPage })));
 const OCRReviewPage = lazy(() => import('./components/OCRReviewPage').then(m => ({ default: m.default || m.OCRReviewPage })));
@@ -76,6 +77,7 @@ function App() {
         <Route path="/teacher/classes/import" element={<LazyProtectedRoute>{(user) => <CSVImportPage user={user} />}</LazyProtectedRoute>} />
         <Route path="/teacher/classes/:classId" element={<LazyProtectedRoute>{(user) => <ClassDetailPage user={user} />}</LazyProtectedRoute>} />
         <Route path="/teacher/classes/:classId/import" element={<LazyProtectedRoute>{(user) => <CSVImportPage user={user} />}</LazyProtectedRoute>} />
+        <Route path="/teacher/students/:studentId" element={<LazyProtectedRoute>{(user) => <StudentDetailPage user={user} />}</LazyProtectedRoute>} />
         <Route path="/teacher/analytics" element={<LazyProtectedRoute>{(user) => <AnalyticsPage user={user} />}</LazyProtectedRoute>} />
         <Route path="/teacher/submissions/:submissionId" element={<LazyProtectedRoute>{(user) => <SubmissionDetailPage user={user} />}</LazyProtectedRoute>} />
         <Route path="/teacher/profile" element={<LazyProtectedRoute>{(user) => <ProfilePage user={user} />}</LazyProtectedRoute>} />

--- a/src/components/AssessmentCard.jsx
+++ b/src/components/AssessmentCard.jsx
@@ -124,29 +124,29 @@ const OverflowMenu = ({ items }) => {
 
 // ─── Countdown display ────────────────────────────────────────────────────────
 
-const TimeDisplay = ({ startedAt, durationMinutes }) => {
+const TimeDisplay = ({ startedAt }) => {
   const [display, setDisplay] = useState("");
 
   useEffect(() => {
-    if (!startedAt || !durationMinutes) return;
+    if (!startedAt) return;
     const tick = () => {
-      const endMs = new Date(startedAt).getTime() + durationMinutes * 60_000;
-      const diffMs = endMs - Date.now();
-      if (diffMs <= 0) { setDisplay("Ended"); return; }
-      const h = Math.floor(diffMs / 3_600_000);
-      const m = Math.floor((diffMs % 3_600_000) / 60_000);
-      const s = Math.floor((diffMs % 60_000) / 1_000);
-      setDisplay(h > 0 ? `${h}h ${m}m remaining` : `${m}m ${s}s remaining`);
+      const elapsedMs = Date.now() - new Date(startedAt).getTime();
+      if (elapsedMs < 0) return;
+      const totalSeconds = Math.floor(elapsedMs / 1_000);
+      const h = Math.floor(totalSeconds / 3_600);
+      const m = Math.floor((totalSeconds % 3_600) / 60);
+      const s = totalSeconds % 60;
+      setDisplay(h > 0 ? `${h}h ${m}m` : `${m}m ${s}s`);
     };
     tick();
     const id = setInterval(tick, 1_000);
     return () => clearInterval(id);
-  }, [startedAt, durationMinutes]);
+  }, [startedAt]);
 
   if (!display) return null;
   return (
     <span className="text-xs font-medium text-orange-600 bg-orange-50 px-2 py-0.5 rounded-full border border-orange-100">
-      ⏱ {display}
+      ⏱ Running {display}
     </span>
   );
 };
@@ -324,7 +324,7 @@ export const AssessmentCard = ({
             <StatusBadge status={a.status} />
             <TypeBadge mode={mode} />
             {isStarted && duration && (
-              <TimeDisplay startedAt={a.started_at} durationMinutes={duration} />
+              <TimeDisplay startedAt={a.started_at} />
             )}
           </div>
           <JoinCodeBlock code={a.join_code} status={a.status} />

--- a/src/components/AssessmentCard.jsx
+++ b/src/components/AssessmentCard.jsx
@@ -192,40 +192,102 @@ const SubmissionsProgress = ({ submitted, total, flagged }) => {
 
 // ─── Join code block ──────────────────────────────────────────────────────────
 
-const JoinCodeBlock = ({ code, status }) => {
+const CopyButton = ({ text, size = 13 }) => {
   const [copied, setCopied] = useState(false);
   const copy = () => {
-    navigator.clipboard.writeText(code).then(() => {
+    navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });
   };
   return (
-    <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
-      <span className="text-[10px] font-medium text-gray-400 uppercase tracking-wider">Join Code</span>
-      <div className="flex items-center gap-1.5">
-        <span
-          className="font-mono text-lg font-bold text-indigo-700 tracking-widest leading-none"
-          data-testid={`join-code-${code}`}
-        >
-          {code}
-        </span>
-        <button
-          onClick={copy}
-          className="p-1 rounded text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
-          title="Copy code"
-        >
-          {copied ? (
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-green-500">
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-          ) : (
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-            </svg>
-          )}
-        </button>
+    <button
+      onClick={copy}
+      className="p-1 rounded text-gray-400 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
+      title="Copy code"
+    >
+      {copied ? (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-green-500">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" /><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+};
+
+// Renders class-specific codes (prominent) + universal code (dimmed).
+// Falls back to the original single-code look when no assignments.
+const JoinCodeBlock = ({ code, status, assignments = [] }) => {
+  if (assignments.length === 0) {
+    return (
+      <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
+        <span className="text-[10px] font-medium text-gray-400 uppercase tracking-wider">Join Code</span>
+        <div className="flex items-center gap-1.5">
+          <span
+            className="font-mono text-lg font-bold text-indigo-700 tracking-widest leading-none"
+            data-testid={`join-code-${code}`}
+          >
+            {code}
+          </span>
+          <CopyButton text={code} />
+        </div>
+        {status === "started" && (
+          <span className="text-[10px] text-gray-400">/join</span>
+        )}
       </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
+      {assignments.map((a) => (
+        <div key={a.id} className="flex items-center gap-1">
+          <div className="flex flex-col items-end">
+            <span
+              className="text-[10px] font-medium text-gray-400 uppercase tracking-wider leading-none mb-0.5 max-w-[120px] truncate"
+              title={a.class_name}
+            >
+              {a.class_name}
+            </span>
+            <div className="flex items-center gap-1">
+              <span
+                className={`font-mono text-base font-bold tracking-widest leading-none ${
+                  a.status === 'open' ? 'text-indigo-700' : 'text-gray-400 line-through'
+                }`}
+                data-testid={`join-code-${a.join_code}`}
+              >
+                {a.join_code}
+              </span>
+              {a.status !== 'open' && (
+                <span className="text-[9px] text-gray-400 font-medium uppercase">closed</span>
+              )}
+            </div>
+          </div>
+          <CopyButton text={a.join_code} size={11} />
+        </div>
+      ))}
+
+      <div className="w-full border-t border-gray-100 pt-1">
+        <div className="flex items-center gap-1 justify-end">
+          <div className="flex flex-col items-end">
+            <span className="text-[10px] font-medium text-gray-300 uppercase tracking-wider leading-none mb-0.5">
+              Universal
+            </span>
+            <span
+              className="font-mono text-sm font-semibold tracking-widest leading-none text-gray-400"
+              data-testid={`join-code-${code}`}
+            >
+              {code}
+            </span>
+          </div>
+          <CopyButton text={code} size={11} />
+        </div>
+      </div>
+
       {status === "started" && (
         <span className="text-[10px] text-gray-400">/join</span>
       )}
@@ -239,6 +301,7 @@ export const AssessmentCard = ({
   assessment: a,
   question,
   classes = [],
+  assignments = [],
   onStart,
   onClose,
   onReopen,
@@ -327,7 +390,7 @@ export const AssessmentCard = ({
               <TimeDisplay startedAt={a.started_at} />
             )}
           </div>
-          <JoinCodeBlock code={a.join_code} status={a.status} />
+          <JoinCodeBlock code={a.join_code} status={a.status} assignments={assignments} />
         </div>
 
         {/* ── Row 2: title ── */}

--- a/src/components/ClassesPage.js
+++ b/src/components/ClassesPage.js
@@ -266,8 +266,8 @@ export const ClassDetailPage = ({ user }) => {
   }, [classId]);
 
   useEffect(() => {
-    if (activeTab === 'assignments') loadAssignments();
-  }, [activeTab, classId]);
+    loadAssignments();
+  }, [classId]);
 
   const loadClassData = async () => {
     try {
@@ -377,18 +377,18 @@ export const ClassDetailPage = ({ user }) => {
               <p className="text-sm text-blue-600">Students</p>
             </div>
             <div className="bg-purple-50 rounded-lg p-4 text-center">
-              <p className="text-3xl font-bold text-purple-600">{classData.assessments.length}</p>
+              <p className="text-3xl font-bold text-purple-600">{assignments.length}</p>
               <p className="text-sm text-purple-600">Assessments</p>
             </div>
             <div className="bg-green-50 rounded-lg p-4 text-center">
               <p className="text-3xl font-bold text-green-600">
-                {classData.assessments.reduce((acc, a) => acc + (a.marked_count || 0), 0)}
+                {assignments.reduce((acc, a) => acc + (a.marked_count || 0), 0)}
               </p>
               <p className="text-sm text-green-600">Marked</p>
             </div>
             <div className="bg-amber-50 rounded-lg p-4 text-center">
               <p className="text-3xl font-bold text-amber-600">
-                {classData.assessments.reduce((acc, a) => acc + (a.submission_count || 0) - (a.marked_count || 0), 0)}
+                {assignments.reduce((acc, a) => acc + (a.submission_count || 0) - (a.marked_count || 0), 0)}
               </p>
               <p className="text-sm text-amber-600">Pending</p>
             </div>
@@ -410,22 +410,12 @@ export const ClassDetailPage = ({ user }) => {
           <button
             onClick={() => setActiveTab('assessments')}
             className={`px-6 py-3 font-medium border-b-2 transition-colors ${
-              activeTab === 'assessments' 
-                ? 'border-blue-600 text-blue-600' 
-                : 'border-transparent text-gray-600 hover:text-gray-900'
-            }`}
-          >
-            Assessments ({classData.assessments.length})
-          </button>
-          <button
-            onClick={() => setActiveTab('assignments')}
-            className={`px-6 py-3 font-medium border-b-2 transition-colors ${
-              activeTab === 'assignments'
+              activeTab === 'assessments'
                 ? 'border-blue-600 text-blue-600'
                 : 'border-transparent text-gray-600 hover:text-gray-900'
             }`}
           >
-            Assignments
+            Assessments ({assignments.length})
           </button>
           <button
             onClick={() => setActiveTab('analytics')}
@@ -534,72 +524,27 @@ export const ClassDetailPage = ({ user }) => {
           <div className="bg-white rounded-lg shadow">
             <div className="p-4 border-b flex justify-between items-center">
               <h3 className="font-semibold text-gray-900">Assessments</h3>
-              <button
-                onClick={() => navigate(`/teacher/assessments/new?classId=${classId}`)}
-                className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 text-sm"
-              >
-                Create Assessment
-              </button>
-            </div>
-
-            {classData.assessments.length === 0 ? (
-              <div className="p-8 text-center text-gray-500">
-                <p>No assessments linked to this class yet.</p>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => navigate('/teacher/assessments/create')}
+                  className="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-200 text-sm"
+                >
+                  Create Assessment
+                </button>
+                <button
+                  onClick={() => setShowAssignModal(true)}
+                  className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 text-sm flex items-center gap-2"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
+                  </svg>
+                  Assign Assessment
+                </button>
               </div>
-            ) : (
-              <div className="divide-y">
-                {classData.assessments.map((assessment) => (
-                  <div key={assessment.id} className="p-4 hover:bg-gray-50">
-                    <div className="flex justify-between items-center">
-                      <div>
-                        <p className="font-medium text-gray-900">Assessment #{assessment.id.slice(0, 8)}</p>
-                        <p className="text-sm text-gray-500">
-                          Join Code: <span className="font-mono text-blue-600">{assessment.join_code}</span>
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-4">
-                        <div className="text-sm text-gray-600">
-                          {assessment.marked_count}/{assessment.submission_count} marked
-                        </div>
-                        <span className={`px-3 py-1 rounded-full text-xs font-medium ${
-                          assessment.status === 'started' ? 'bg-green-100 text-green-700' :
-                          assessment.status === 'closed' ? 'bg-gray-100 text-gray-700' :
-                          'bg-amber-100 text-amber-700'
-                        }`}>
-                          {assessment.status}
-                        </span>
-                        <button
-                          onClick={() => navigate(`/teacher/assessments/${assessment.id}`)}
-                          className="text-blue-600 hover:text-blue-700 text-sm"
-                        >
-                          View →
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {activeTab === 'assignments' && (
-          <div className="bg-white rounded-lg shadow">
-            <div className="p-4 border-b flex justify-between items-center">
-              <h3 className="font-semibold text-gray-900">Assigned Assessments</h3>
-              <button
-                onClick={() => setShowAssignModal(true)}
-                className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 text-sm flex items-center gap-2"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M12 4v16m8-8H4" />
-                </svg>
-                Assign Assessment
-              </button>
             </div>
 
             {assignmentsLoading ? (
-              <div className="p-8 text-center text-gray-500">Loading assignments...</div>
+              <div className="p-8 text-center text-gray-500">Loading...</div>
             ) : assignments.length === 0 ? (
               <div className="p-8 text-center text-gray-500">
                 <p>No assessments assigned to this class yet.</p>
@@ -649,7 +594,7 @@ export const ClassDetailPage = ({ user }) => {
                           {assignment.status === 'open' ? 'Close' : 'Reopen'}
                         </button>
                         <button
-                          onClick={() => navigate(`/teacher/assignments/${assignment.id}/submissions`)}
+                          onClick={() => navigate(`/teacher/assessments/${assignment.assessment_id}/enhanced`)}
                           className="px-3 py-1.5 rounded-lg text-sm font-medium bg-blue-100 text-blue-700 hover:bg-blue-200"
                         >
                           View
@@ -1550,6 +1495,159 @@ const EditClassModal = ({ classData, onClose, onUpdated }) => {
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  );
+};
+
+// Student Detail Page
+export const StudentDetailPage = ({ user }) => {
+  const { studentId } = useParams();
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await axios.get(`${API}/teacher/students/${studentId}`);
+        setData(res.data);
+      } catch (err) {
+        setError(getApiErrorMessage(err, 'Failed to load student'));
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [studentId]);
+
+  if (loading) return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+
+  if (error) return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar user={user} />
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4">{error}</div>
+      </div>
+    </div>
+  );
+
+  const { student, class: cls, submissions, stats } = data;
+
+  const displayName = student.preferred_name
+    ? `${student.first_name} "${student.preferred_name}" ${student.last_name}`
+    : `${student.first_name} ${student.last_name}`;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navbar user={user} />
+      <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+
+        {/* Header */}
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => navigate(cls ? `/teacher/classes/${cls.id}` : '/teacher/classes')}
+            className="text-gray-500 hover:text-gray-700 text-sm"
+          >
+            ← {cls ? cls.class_name : 'Classes'}
+          </button>
+        </div>
+
+        <div className="bg-white rounded-xl shadow p-6">
+          <div className="flex items-start justify-between gap-4 flex-wrap">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">{displayName}</h1>
+              {cls && <p className="text-sm text-gray-500 mt-0.5">{cls.class_name}</p>}
+              <div className="flex flex-wrap gap-2 mt-3">
+                {student.sen_flag && <span className="bg-purple-100 text-purple-700 px-2 py-1 rounded text-xs font-medium">SEN</span>}
+                {student.pupil_premium_flag && <span className="bg-amber-100 text-amber-700 px-2 py-1 rounded text-xs font-medium">Pupil Premium</span>}
+                {student.eal_flag && <span className="bg-blue-100 text-blue-700 px-2 py-1 rounded text-xs font-medium">EAL</span>}
+              </div>
+            </div>
+            <button
+              onClick={() => navigate(`/teacher/classes/${student.class_id}`)}
+              className="px-4 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
+            >
+              Back to Class
+            </button>
+          </div>
+
+          <div className="mt-5 grid grid-cols-2 sm:grid-cols-4 gap-4 border-t pt-5">
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Email</p>
+              <p className="text-sm text-gray-800 mt-0.5 break-all">{student.email || '—'}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Candidate No.</p>
+              <p className="text-sm text-gray-800 mt-0.5">{student.candidate_number || student.student_code || '—'}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Assessments</p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">{stats.total_submissions}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">Average Score</p>
+              <p className="text-sm font-semibold text-gray-900 mt-0.5">
+                {stats.average_score !== null ? `${stats.average_score}%` : '—'}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Submissions */}
+        <div className="bg-white rounded-xl shadow">
+          <div className="px-6 py-4 border-b">
+            <h2 className="font-semibold text-gray-900">Assessment History</h2>
+          </div>
+          {submissions.length === 0 ? (
+            <p className="px-6 py-8 text-center text-gray-400 text-sm">No submissions yet.</p>
+          ) : (
+            <div className="divide-y">
+              {submissions.map(sub => {
+                const isEnhanced = sub.answers?.length > 0 || (sub.assessment_mode && sub.assessment_mode !== 'CLASSIC');
+                const detailPath = isEnhanced
+                  ? `/teacher/submissions/${sub.attempt_id}/enhanced`
+                  : `/teacher/submissions/${sub.attempt_id}`;
+                const score = sub.totalScore ?? sub.score;
+                const total = sub.totalMarks;
+                const pct = sub.percentage ?? (score != null && total > 0 ? Math.round((score / total) * 100) : null);
+                const submittedAt = sub.submitted_at ? new Date(sub.submitted_at).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '—';
+                const statusColors = {
+                  marked: 'bg-green-100 text-green-700',
+                  submitted: 'bg-blue-100 text-blue-700',
+                  in_progress: 'bg-yellow-100 text-yellow-700',
+                };
+
+                return (
+                  <div key={sub.attempt_id} className="px-6 py-4 flex items-center justify-between gap-4">
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {sub.assessment_title || `Assessment ${sub.assessment_id?.slice(0, 8) || ''}`}
+                      </p>
+                      <p className="text-xs text-gray-400 mt-0.5">{submittedAt}</p>
+                    </div>
+                    <div className="flex items-center gap-3 shrink-0">
+                      {pct !== null && (
+                        <span className="text-sm font-semibold text-gray-700">{pct}%</span>
+                      )}
+                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusColors[sub.status] || 'bg-gray-100 text-gray-600'}`}>
+                        {sub.status?.replace('_', ' ')}
+                      </span>
+                      <button
+                        onClick={() => navigate(detailPath)}
+                        className="text-blue-600 hover:text-blue-700 text-sm font-medium"
+                      >
+                        View →
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
       </div>
     </div>
   );

--- a/src/components/TeacherPages.js
+++ b/src/components/TeacherPages.js
@@ -15,6 +15,7 @@ export const AssessmentsPage = ({ user }) => {
   const [questions, setQuestions] = useState([]);
   const [classes, setClasses] = useState([]);
   const [templates, setTemplates] = useState([]);
+  const [assignmentsByAssessment, setAssignmentsByAssessment] = useState({});
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [showTemplateForm, setShowTemplateForm] = useState(false);
@@ -45,17 +46,24 @@ export const AssessmentsPage = ({ user }) => {
 
   const loadData = async () => {
     try {
-      const [assessmentsRes, questionsRes, classesRes, templatesRes] =
+      const [assessmentsRes, questionsRes, classesRes, templatesRes, assignmentsRes] =
         await Promise.all([
           axios.get(`${API}/teacher/assessments`),
           axios.get(`${API}/teacher/questions`),
           axios.get(`${API}/teacher/classes`),
           axios.get(`${API}/teacher/templates`),
+          axios.get(`${API}/teacher/assignments`).catch(() => ({ data: { assignments: [] } })),
         ]);
       setAssessments(assessmentsRes.data);
       setQuestions(questionsRes.data);
       setClasses(classesRes.data.classes || []);
       setTemplates(templatesRes.data.templates || []);
+      const grouped = {};
+      for (const a of (assignmentsRes.data.assignments || [])) {
+        if (!grouped[a.assessment_id]) grouped[a.assessment_id] = [];
+        grouped[a.assessment_id].push(a);
+      }
+      setAssignmentsByAssessment(grouped);
       setLoading(false);
     } catch (error) {
       setLoading(false);
@@ -729,6 +737,7 @@ export const AssessmentsPage = ({ user }) => {
                               assessment={a}
                               question={question}
                               classes={classes}
+                              assignments={assignmentsByAssessment[a.id] || []}
                               onStart={() => handleStart(a.id)}
                               onClose={() => handleClose(a.id)}
                               onReopen={() => handleReopen(a.id)}

--- a/src/pages/EnhancedAssessmentBuilderPage.js
+++ b/src/pages/EnhancedAssessmentBuilderPage.js
@@ -43,6 +43,10 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     class_id: null
   });
 
+  const [selectedClassIds, setSelectedClassIds] = useState([]);
+  const [classes, setClasses] = useState([]);
+  const [classesLoading, setClassesLoading] = useState(false);
+
   const [showAIBulk, setShowAIBulk] = useState(false);
   const [extracting, setExtracting] = useState(false);
   const [extractProgress, setExtractProgress] = useState(0);
@@ -174,6 +178,21 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
     }
   }, [assessmentId]);
 
+  useEffect(() => {
+    const fetchClasses = async () => {
+      setClassesLoading(true);
+      try {
+        const res = await axios.get(`${API}/teacher/classes`);
+        setClasses(res.data.classes || []);
+      } catch (e) {
+        // non-fatal — teacher can still see the empty state
+      } finally {
+        setClassesLoading(false);
+      }
+    };
+    fetchClasses();
+  }, []);
+
   const loadAssessment = async () => {
     try {
       const response = await axios.get(`${API}/teacher/assessments/${assessmentId}/enhanced`);
@@ -213,6 +232,20 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
   const updateField = useCallback((field, value) => {
     setAssessmentData(prev => ({ ...prev, [field]: value }));
   }, []);
+
+  const toggleClass = useCallback((classId) => {
+    setSelectedClassIds(prev =>
+      prev.includes(classId) ? prev.filter(id => id !== classId) : [...prev, classId]
+    );
+  }, []);
+
+  const createAssignments = async (newAssessmentId) => {
+    await Promise.all(
+      selectedClassIds.map(classId =>
+        axios.post(`${API}/teacher/assessments/${newAssessmentId}/assignments`, { class_id: classId })
+      )
+    );
+  };
 
   const addQuestion = useCallback(() => {
     setAssessmentData(prev => {
@@ -291,6 +324,12 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
       return false;
     }
 
+    if (!isEdit && selectedClassIds.length === 0) {
+      showNotification('Please assign this assessment to at least one class', 'error');
+      setCurrentStep(2);
+      return false;
+    }
+
     if (assessmentData.questions.length === 0) {
       showNotification('Please add at least one question', 'error');
       return false;
@@ -350,6 +389,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
           const payload = isOcrMode ? { ...assessmentData, ocrConfirmed: true } : assessmentData;
           const response = await axios.post(`${API}/teacher/assessments/enhanced`, payload);
           const newId = response.data.assessment.id;
+          await createAssignments(newId);
           showNotification('Assessment created as draft!', 'success');
           navigate(`/teacher/assessments/${newId}/enhanced`);
         }
@@ -377,6 +417,7 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
           const payload = isOcrMode ? { ...assessmentData, ocrConfirmed: true } : assessmentData;
           const response = await axios.post(`${API}/teacher/assessments/enhanced`, payload);
           finalAssessmentId = response.data.assessment.id;
+          await createAssignments(finalAssessmentId);
         } else {
           await axios.put(`${API}/teacher/assessments/${assessmentId}/questions`, {
             questions: assessmentData.questions,
@@ -603,12 +644,45 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               <p className="text-xs text-gray-400 mt-1">Enabled tools appear as toggle buttons on the right side of the student's screen during the assessment.</p>
             </div>
 
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Assign to Classes *
+                <span className="ml-1 font-normal text-gray-400 text-xs">— at least one required</span>
+              </label>
+              {classesLoading ? (
+                <p className="text-sm text-gray-400">Loading classes...</p>
+              ) : classes.length === 0 ? (
+                <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-700">
+                  No classes yet. <a href="/teacher/classes" className="underline font-medium">Create a class first</a>, then come back.
+                </div>
+              ) : (
+                <div className={`border rounded-lg divide-y max-h-48 overflow-y-auto ${selectedClassIds.length === 0 ? 'border-red-300' : 'border-gray-200'}`}>
+                  {classes.map(cls => (
+                    <label key={cls.id} className="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="rounded"
+                        checked={selectedClassIds.includes(cls.id)}
+                        onChange={() => toggleClass(cls.id)}
+                      />
+                      <span className="text-sm text-gray-800 flex-1">{cls.class_name}</span>
+                      <span className="text-xs text-gray-400">{cls.student_count} student{cls.student_count !== 1 ? 's' : ''}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+              {selectedClassIds.length === 0 && classes.length > 0 && (
+                <p className="mt-1 text-xs text-red-500">Select at least one class to continue.</p>
+              )}
+            </div>
+
             <div className="flex justify-between pt-4 border-t">
               <button onClick={() => setCurrentStep(1)} className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50">← Back</button>
               <button
                 onClick={() => {
                   if (!assessmentData.title.trim()) { showNotification('Assessment title is required', 'error'); return; }
                   if (!assessmentData.subject) { showNotification('Subject is required', 'error'); return; }
+                  if (selectedClassIds.length === 0) { showNotification('Please assign this assessment to at least one class', 'error'); return; }
                   setCurrentStep(3);
                 }}
                 className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
@@ -778,9 +852,47 @@ export const EnhancedAssessmentBuilderPage = ({ user }) => {
               <p className="text-xs text-gray-400 mt-1">Enabled tools appear as toggle buttons on the right side of the student's screen during the assessment.</p>
             </div>
 
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Assign to Classes *
+                <span className="ml-1 font-normal text-gray-400 text-xs">— at least one required</span>
+              </label>
+              {classesLoading ? (
+                <p className="text-sm text-gray-400">Loading classes...</p>
+              ) : classes.length === 0 ? (
+                <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg text-sm text-amber-700">
+                  No classes yet. <a href="/teacher/classes" className="underline font-medium">Create a class first</a>, then come back.
+                </div>
+              ) : (
+                <div className={`border rounded-lg divide-y max-h-48 overflow-y-auto ${selectedClassIds.length === 0 ? 'border-red-300' : 'border-gray-200'}`}>
+                  {classes.map(cls => (
+                    <label key={cls.id} className="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="rounded"
+                        checked={selectedClassIds.includes(cls.id)}
+                        onChange={() => toggleClass(cls.id)}
+                      />
+                      <span className="text-sm text-gray-800 flex-1">{cls.class_name}</span>
+                      <span className="text-xs text-gray-400">{cls.student_count} student{cls.student_count !== 1 ? 's' : ''}</span>
+                    </label>
+                  ))}
+                </div>
+              )}
+              {selectedClassIds.length === 0 && classes.length > 0 && (
+                <p className="mt-1 text-xs text-red-500">Select at least one class to continue.</p>
+              )}
+            </div>
+
             <div className="flex justify-between pt-4 border-t">
               <button onClick={() => setCurrentStep(1)} className="px-6 py-2 border border-gray-300 rounded-lg hover:bg-gray-50">← Back</button>
-              <button onClick={() => setCurrentStep(3)} className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+              <button
+                onClick={() => {
+                  if (selectedClassIds.length === 0) { showNotification('Please assign this assessment to at least one class', 'error'); return; }
+                  setCurrentStep(3);
+                }}
+                className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              >
                 Next: Add Questions →
               </button>
             </div>

--- a/src/pages/EnhancedAssessmentDetailPage.js
+++ b/src/pages/EnhancedAssessmentDetailPage.js
@@ -17,6 +17,7 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
   const [selectedClassId, setSelectedClassId] = useState('');
   const [assigning, setAssigning] = useState(false);
   const [assignResult, setAssignResult] = useState(null);
+  const [detailAssignments, setDetailAssignments] = useState([]);
 
   useEffect(() => {
     loadData();
@@ -24,8 +25,12 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
 
   const loadData = async () => {
     try {
-      const response = await axios.get(`${API}/teacher/assessments/${assessmentId}/enhanced`);
-      setData(response.data);
+      const [assessmentRes, assignmentsRes] = await Promise.all([
+        axios.get(`${API}/teacher/assessments/${assessmentId}/enhanced`),
+        axios.get(`${API}/teacher/assessments/${assessmentId}/assignments`).catch(() => ({ data: { assignments: [] } })),
+      ]);
+      setData(assessmentRes.data);
+      setDetailAssignments(assignmentsRes.data.assignments || []);
       setLoading(false);
     } catch (error) {
       setLoading(false);
@@ -129,6 +134,7 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
     try {
       const res = await axios.post(`${API}/teacher/assessments/${assessmentId}/assignments`, { class_id: selectedClassId });
       setAssignResult(res.data);
+      loadData();
     } catch (error) {
       handleApiError(error, 'Failed to assign assessment');
     }
@@ -178,7 +184,26 @@ export const EnhancedAssessmentDetailPage = ({ user }) => {
                 </div>
                 <div>
                   <p><strong>Duration:</strong> {assessment.durationMinutes} minutes</p>
-                  <p><strong>Join Code:</strong> <span className="text-blue-600 font-bold">{assessment.join_code}</span></p>
+                  {detailAssignments.length > 0 ? (
+                    <div>
+                      <strong>Class Join Codes:</strong>
+                      <div className="mt-1 space-y-1">
+                        {detailAssignments.map(a => (
+                          <div key={a.id} className="flex items-center gap-2 text-sm">
+                            <span className="font-mono font-bold text-blue-600">{a.join_code}</span>
+                            <span className="text-gray-500">— {a.class_name}</span>
+                            <span className={`text-xs px-1.5 py-0.5 rounded-full font-medium ${
+                              a.status === 'open' ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'
+                            }`}>
+                              {a.status}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    <p><strong>Join Code:</strong> <span className="text-blue-600 font-bold">{assessment.join_code}</span></p>
+                  )}
                   <p><strong>Submissions:</strong> {attempts_count}</p>
                 </div>
               </div>

--- a/src/pages/JoinPage.js
+++ b/src/pages/JoinPage.js
@@ -6,48 +6,10 @@ import { getApiErrorMessage } from '@/lib/handle-error';
 
 export const JoinPage = () => {
   const [joinCode, setJoinCode] = useState('');
-  const [studentName, setStudentName] = useState('');
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [candidateNumber, setCandidateNumber] = useState('');
+  const [studentEmail, setStudentEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  
-  // Phase 4: Class-linked assessment state
-  const [checkingCode, setCheckingCode] = useState(false);
-  const [classRoster, setClassRoster] = useState(null);
-  const [selectedStudentId, setSelectedStudentId] = useState('');
-
-  // Check if the code is an assignment code or class-linked assessment when entered
-  const handleCodeChange = async (code) => {
-    setJoinCode(code.toUpperCase());
-    setClassRoster(null);
-    setSelectedStudentId('');
-    setStudentName('');
-    setFirstName('');
-    setLastName('');
-    setCandidateNumber('');
-    setError('');
-
-    if (code.length === 6) {
-      setCheckingCode(true);
-      try {
-        const response = await axios.get(`${API}/public/assessment/${code.toUpperCase()}/class-roster`);
-        if (response.data.has_roster && response.data.students.length > 0) {
-          setClassRoster(response.data);
-        }
-        // type=assignment or has_roster=false → just show the manual name form (no action needed)
-      } catch (err) {
-        // 400 means the code is valid but the assessment/assignment is closed
-        if (err.response?.status === 400) {
-          setError('This assessment is now closed. Contact your teacher.');
-        }
-        // 404 = invalid code — let the submit button validate it on submit
-      }
-      setCheckingCode(false);
-    }
-  };
 
   const handleJoin = async (e) => {
     e.preventDefault();
@@ -55,39 +17,21 @@ export const JoinPage = () => {
     setError('');
 
     try {
-      const fullName = classRoster ? studentName : `${firstName.trim()} ${lastName.trim()}`.trim();
-      const payload = {
+      const response = await axios.post(`${API}/public/join`, {
         join_code: joinCode.toUpperCase(),
-        student_name: fullName
-      };
-      
-      // Phase 4: Include student_id if selected from roster
-      if (classRoster && selectedStudentId) {
-        payload.student_id = selectedStudentId;
-        // Use display name from roster
-        const selectedStudent = classRoster.students.find(s => s.id === selectedStudentId);
-        if (selectedStudent) {
-          payload.student_name = selectedStudent.display_name;
-        }
-      }
-      
-      const response = await axios.post(`${API}/public/join`, payload);
-      
-      // Check if it's an Enhanced Assessment
-      const attemptId = response.data.attempt_id;
-      const isEnhanced = response.data.is_enhanced || false;
-      
-      if (isEnhanced) {
-        navigate(`/enhanced-attempt/${attemptId}`);
-      } else {
-        navigate(`/attempt/${attemptId}`);
-      }
+        student_email: studentEmail.trim(),
+      });
+
+      const { attempt_id, is_enhanced } = response.data;
+      navigate(is_enhanced ? `/enhanced-attempt/${attempt_id}` : `/attempt/${attempt_id}`);
     } catch (err) {
       const msg = err.response?.data?.detail || '';
       if (msg === 'Invalid join code') {
         setError('Invalid join code. Please check the code and try again.');
       } else if (msg === 'This assessment is now closed') {
         setError('This assessment is now closed. Contact your teacher.');
+      } else if (msg === 'You are not enrolled in this class') {
+        setError('Your email address was not found in this class. Contact your teacher if this is incorrect.');
       } else {
         setError(getApiErrorMessage(err, 'Failed to join assessment'));
       }
@@ -100,119 +44,60 @@ export const JoinPage = () => {
       <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full" data-testid="join-container">
         <div className="mb-6 text-center">
           <p className="text-sm font-semibold text-blue-600 mb-2">BlueAI Assess</p>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2" data-testid="join-title">Enter your assessment code</h1>
-          <p className="text-gray-600">Use the join code provided by your teacher.</p>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2" data-testid="join-title">Join your assessment</h1>
+          <p className="text-gray-600">Enter your assessment code and school email to begin.</p>
         </div>
 
         <form onSubmit={handleJoin} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2" data-testid="code-label">Assessment Code</label>
-            <div className="relative">
-              <input
-                data-testid="code-input"
-                type="text"
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 uppercase"
-                value={joinCode}
-                onChange={(e) => handleCodeChange(e.target.value)}
-                required
-                maxLength={6}
-                placeholder="e.g., ABC123"
-              />
-              {checkingCode && (
-                <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
-                </div>
-              )}
-            </div>
+            <label className="block text-sm font-medium text-gray-700 mb-2" data-testid="code-label">
+              Assessment Code
+            </label>
+            <input
+              data-testid="code-input"
+              type="text"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 uppercase tracking-widest text-center text-lg font-semibold"
+              value={joinCode}
+              onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+              required
+              maxLength={6}
+              placeholder="ABC123"
+              autoComplete="off"
+            />
           </div>
 
-          {/* Phase 4: Show class roster dropdown if assessment is class-linked */}
-          {classRoster && (
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">
-                Select Your Name ({classRoster.class_name})
-              </label>
-              <select
-                data-testid="student-select"
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                value={selectedStudentId}
-                onChange={(e) => {
-                  setSelectedStudentId(e.target.value);
-                  const student = classRoster.students.find(s => s.id === e.target.value);
-                  if (student) setStudentName(student.display_name);
-                }}
-                required
-              >
-                <option value="">-- Select your name --</option>
-                {classRoster.students.map((student) => (
-                  <option key={student.id} value={student.id}>
-                    {student.display_name}
-                  </option>
-                ))}
-              </select>
-              <p className="text-xs text-gray-500 mt-1">
-                Can't find your name? Contact your teacher.
-              </p>
-            </div>
-          )}
-
-          {/* Show manual details only if NOT class-linked */}
-          {!classRoster && (
-            <>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2" data-testid="first-name-label">First name</label>
-                  <input
-                    data-testid="first-name-input"
-                    type="text"
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    value={firstName}
-                    onChange={(e) => setFirstName(e.target.value)}
-                    required
-                    placeholder="First name"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2" data-testid="last-name-label">Last name</label>
-                  <input
-                    data-testid="last-name-input"
-                    type="text"
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    value={lastName}
-                    onChange={(e) => setLastName(e.target.value)}
-                    required
-                    placeholder="Last name"
-                  />
-                </div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2" data-testid="candidate-label">
-                  Student / candidate number <span className="font-normal text-gray-500">(optional)</span>
-                </label>
-                <input
-                  data-testid="candidate-input"
-                  type="text"
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  value={candidateNumber}
-                  onChange={(e) => setCandidateNumber(e.target.value)}
-                  placeholder="e.g., 1042"
-                />
-              </div>
-            </>
-          )}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2" data-testid="email-label">
+              School email address
+            </label>
+            <input
+              data-testid="email-input"
+              type="email"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              value={studentEmail}
+              onChange={(e) => setStudentEmail(e.target.value)}
+              required
+              placeholder="your.name@school.ac.uk"
+              autoComplete="email"
+            />
+            <p className="text-xs text-gray-500 mt-1">
+              Use the email address your teacher has on record for you.
+            </p>
+          </div>
 
           {error && (
-            <div className="bg-red-50 text-red-700 p-3 rounded-lg text-sm" data-testid="join-error">{error}</div>
+            <div className="bg-red-50 border border-red-200 text-red-700 p-3 rounded-lg text-sm" data-testid="join-error">
+              {error}
+            </div>
           )}
 
           <button
             data-testid="join-submit-btn"
             type="submit"
-            className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
-            disabled={loading || (classRoster && !selectedStudentId)}
+            disabled={loading || !joinCode.trim() || !studentEmail.trim()}
+            className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {loading ? 'Joining...' : 'Start Assessment'}
+            {loading ? 'Checking...' : 'Join Assessment'}
           </button>
         </form>
       </div>


### PR DESCRIPTION
Added:
- Student join page now shows two fields only: Assessment Code and School Email — backend resolves the student's name automatically
- Class multi-select added to Step 2 of the assessment builder — at least one class must be selected before saving or publishing
Student detail page at `/teacher/students/:studentId` showing name, class, SEN/PP/EAL badges, assessment history and stats

Updated:
- Assessment card now shows elapsed running time ("Running 4m 32s") instead of a misleading countdown to "Ended"
Class detail Assessments tab now pulls from the assignments API and shows the correct class-specific join code, assessment title and submission counts
- Assessment detail page also shows the class-specific join code(s) with class name and open/closed status instead of the generic direct code
- "Create Assessment" button on the class detail page now navigates to the correct route

Removed:
- Redundant "Assignments" tab from class detail page (merged into the Assessments tab)