### PR TITLE
[167] Add usage tiering, dashboard metrics and admin page

### DIFF
--- a/src/components/AdminPages.js
+++ b/src/components/AdminPages.js
@@ -1,33 +1,227 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { API } from '@/config';
 import { handleApiError } from '@/lib/handle-error';
 import { Navbar } from './Navbar';
 
+const ACCOUNT_TYPES = ['free_tester', 'paid', 'extended', 'pilot', 'internal'];
+const ACCOUNT_TYPE_LABELS = {
+  free_tester: 'Free Trial',
+  paid: 'Paid',
+  extended: 'Extended',
+  pilot: 'Pilot',
+  internal: 'Internal',
+};
+const ACCOUNT_TYPE_COLORS = {
+  free_tester: 'bg-gray-100 text-gray-700',
+  paid: 'bg-green-100 text-green-700',
+  extended: 'bg-blue-100 text-blue-700',
+  pilot: 'bg-purple-100 text-purple-700',
+  internal: 'bg-indigo-100 text-indigo-700',
+};
+
+function QuotaBar({ used, allowance }) {
+  if (!allowance) return <span className="text-gray-400 text-xs">—</span>;
+  const pct = Math.min(100, Math.round((used / allowance) * 100));
+  const color = pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-blue-500';
+  return (
+    <div className="flex items-center gap-2 min-w-[100px]">
+      <div className="flex-1 h-1.5 bg-gray-200 rounded-full overflow-hidden">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span className="text-xs text-gray-600 whitespace-nowrap">{used}/{allowance}</span>
+    </div>
+  );
+}
+
+function UsageEditModal({ entry, onClose, onSave }) {
+  const { user, raw_quota } = entry;
+  const [form, setForm] = useState({
+    account_type: raw_quota.account_type || 'free_tester',
+    ocr_pages_allowance: raw_quota.ocr_pages_allowance ?? 50,
+    ai_marking_allowance: raw_quota.ai_marking_allowance ?? 50,
+    pdf_export_allowance: raw_quota.pdf_export_allowance ?? 20,
+    max_assessments: raw_quota.max_assessments ?? 10,
+    max_classes: raw_quota.max_classes ?? 5,
+    trial_end_date: raw_quota.trial_end_date ? raw_quota.trial_end_date.split('T')[0] : '',
+    notes: raw_quota.notes || '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const payload = { ...form };
+      if (payload.trial_end_date) {
+        payload.trial_end_date = new Date(payload.trial_end_date).toISOString();
+      } else {
+        delete payload.trial_end_date;
+      }
+      await axios.put(`${API}/admin/usage/${user.user_id}`, payload);
+      onSave();
+    } catch (e) {
+      setError(e.response?.data?.detail || 'Failed to save');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    if (!window.confirm(`Reset all usage counters for ${user.name} to zero?`)) return;
+    setSaving(true);
+    try {
+      await axios.post(`${API}/admin/usage/${user.user_id}/reset`);
+      onSave();
+    } catch (e) {
+      setError(e.response?.data?.detail || 'Failed to reset');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg">
+        <div className="px-6 py-4 border-b flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900">Edit Quota</h3>
+            <p className="text-sm text-gray-500">{user.name} — {user.email}</p>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 text-xl">✕</button>
+        </div>
+
+        <div className="px-6 py-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Account Type</label>
+            <select
+              value={form.account_type}
+              onChange={e => setForm(f => ({ ...f, account_type: e.target.value }))}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500"
+            >
+              {ACCOUNT_TYPES.map(t => (
+                <option key={t} value={t}>{ACCOUNT_TYPE_LABELS[t]}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            {[
+              { key: 'ocr_pages_allowance', label: 'OCR Pages Allowance' },
+              { key: 'ai_marking_allowance', label: 'AI Marking Allowance' },
+              { key: 'pdf_export_allowance', label: 'PDF Export Allowance' },
+              { key: 'max_assessments', label: 'Max Assessments' },
+              { key: 'max_classes', label: 'Max Classes' },
+            ].map(({ key, label }) => (
+              <div key={key}>
+                <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+                <input
+                  type="number"
+                  min="0"
+                  value={form[key]}
+                  onChange={e => setForm(f => ({ ...f, [key]: parseInt(e.target.value) || 0 }))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            ))}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Trial End Date</label>
+              <input
+                type="date"
+                value={form.trial_end_date}
+                onChange={e => setForm(f => ({ ...f, trial_end_date: e.target.value }))}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+            <textarea
+              value={form.notes}
+              onChange={e => setForm(f => ({ ...f, notes: e.target.value }))}
+              rows={2}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500"
+              placeholder="Optional internal notes..."
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>}
+        </div>
+
+        <div className="px-6 py-4 border-t flex items-center justify-between">
+          <button
+            onClick={handleReset}
+            disabled={saving}
+            className="text-sm text-red-600 hover:text-red-700 font-medium disabled:opacity-50"
+          >
+            Reset Usage Counters
+          </button>
+          <div className="flex gap-3">
+            <button onClick={onClose} className="px-4 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50">
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={saving}
+              className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : 'Save Changes'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export const AdminDashboard = ({ user }) => {
+  const [activeTab, setActiveTab] = useState('teachers');
   const [teachers, setTeachers] = useState([]);
   const [assessments, setAssessments] = useState([]);
+  const [usageData, setUsageData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [usageLoading, setUsageLoading] = useState(false);
+  const [editingEntry, setEditingEntry] = useState(null);
   const navigate = useNavigate();
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       const [teachersRes, assessmentsRes] = await Promise.all([
         axios.get(`${API}/admin/teachers`),
-        axios.get(`${API}/admin/assessments`)
+        axios.get(`${API}/admin/assessments`),
       ]);
       setTeachers(teachersRes.data);
       setAssessments(assessmentsRes.data);
-      setLoading(false);
-    } catch (error) {
+    } catch {
+      // silent
+    } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  const loadUsage = useCallback(async () => {
+    setUsageLoading(true);
+    try {
+      const res = await axios.get(`${API}/admin/usage`);
+      setUsageData(res.data);
+    } catch {
+      // silent
+    } finally {
+      setUsageLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  useEffect(() => {
+    if (activeTab === 'usage') loadUsage();
+  }, [activeTab, loadUsage]);
 
   const handleRoleChange = async (teacherId, newRole) => {
     try {
@@ -38,91 +232,225 @@ export const AdminDashboard = ({ user }) => {
     }
   };
 
+  const tabs = [
+    { id: 'teachers', label: `Teachers (${teachers.length})` },
+    { id: 'assessments', label: `Assessments (${assessments.length})` },
+    { id: 'usage', label: 'Usage & Quotas' },
+  ];
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Navbar user={user} />
 
       <div className="max-w-7xl mx-auto px-6 py-8">
-        <h2 className="text-3xl font-bold text-gray-900 mb-8" data-testid="admin-title">Admin Dashboard</h2>
+        <h2 className="text-3xl font-bold text-gray-900 mb-6" data-testid="admin-title">Admin Dashboard</h2>
 
-        <div className="bg-white p-6 rounded-lg shadow mb-8">
-          <h3 className="text-xl font-semibold text-gray-900 mb-4" data-testid="teachers-title">Teachers ({teachers.length})</h3>
-          
-          {loading ? (
-            <div className="text-center py-8">Loading...</div>
-          ) : teachers.length === 0 ? (
-            <p className="text-gray-600 text-center py-8">No teachers yet</p>
-          ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full" data-testid="teachers-table">
-                <thead>
-                  <tr className="border-b">
-                    <th className="text-left py-3 px-4 text-gray-700 font-medium">Name</th>
-                    <th className="text-left py-3 px-4 text-gray-700 font-medium">Email</th>
-                    <th className="text-left py-3 px-4 text-gray-700 font-medium">Role</th>
-                    <th className="text-left py-3 px-4 text-gray-700 font-medium">Actions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {teachers.map((t) => (
-                    <tr key={t.user_id} className="border-b" data-testid={`teacher-${t.user_id}`}>
-                      <td className="py-3 px-4">{t.name}</td>
-                      <td className="py-3 px-4 text-gray-600">{t.email}</td>
-                      <td className="py-3 px-4">
-                        <span className={`px-3 py-1 rounded-full text-xs font-medium ${t.role === 'admin' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>
-                          {t.role}
-                        </span>
-                      </td>
-                      <td className="py-3 px-4">
-                        {t.user_id !== user.user_id && (
-                          <select
-                            value={t.role}
-                            onChange={(e) => handleRoleChange(t.user_id, e.target.value)}
-                            className="px-2 py-1 border rounded text-sm"
-                            data-testid={`role-select-${t.user_id}`}
-                          >
-                            <option value="teacher">Teacher</option>
-                            <option value="admin">Admin</option>
-                          </select>
-                        )}
-                      </td>
+        {/* Tabs */}
+        <div className="flex gap-1 mb-6 border-b border-gray-200">
+          {tabs.map(tab => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${
+                activeTab === tab.id
+                  ? 'border-blue-600 text-blue-700 bg-blue-50'
+                  : 'border-transparent text-gray-500 hover:text-gray-700'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Teachers tab */}
+        {activeTab === 'teachers' && (
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h3 className="text-xl font-semibold text-gray-900 mb-4" data-testid="teachers-title">
+              Teachers ({teachers.length})
+            </h3>
+            {loading ? (
+              <div className="text-center py-8">Loading...</div>
+            ) : teachers.length === 0 ? (
+              <p className="text-gray-600 text-center py-8">No teachers yet</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full" data-testid="teachers-table">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="text-left py-3 px-4 text-gray-700 font-medium">Name</th>
+                      <th className="text-left py-3 px-4 text-gray-700 font-medium">Email</th>
+                      <th className="text-left py-3 px-4 text-gray-700 font-medium">Role</th>
+                      <th className="text-left py-3 px-4 text-gray-700 font-medium">Actions</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
+                  </thead>
+                  <tbody>
+                    {teachers.map((t) => (
+                      <tr key={t.user_id} className="border-b" data-testid={`teacher-${t.user_id}`}>
+                        <td className="py-3 px-4">{t.name}</td>
+                        <td className="py-3 px-4 text-gray-600">{t.email}</td>
+                        <td className="py-3 px-4">
+                          <span className={`px-3 py-1 rounded-full text-xs font-medium ${t.role === 'admin' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>
+                            {t.role}
+                          </span>
+                        </td>
+                        <td className="py-3 px-4">
+                          {t.user_id !== user.user_id && (
+                            <select
+                              value={t.role}
+                              onChange={(e) => handleRoleChange(t.user_id, e.target.value)}
+                              className="px-2 py-1 border rounded text-sm"
+                              data-testid={`role-select-${t.user_id}`}
+                            >
+                              <option value="teacher">Teacher</option>
+                              <option value="admin">Admin</option>
+                            </select>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
 
-        <div className="bg-white p-6 rounded-lg shadow">
-          <h3 className="text-xl font-semibold text-gray-900 mb-4" data-testid="all-assessments-title">All Assessments ({assessments.length})</h3>
-          
-          {loading ? (
-            <div className="text-center py-8">Loading...</div>
-          ) : assessments.length === 0 ? (
-            <p className="text-gray-600 text-center py-8">No assessments yet</p>
-          ) : (
-            <div className="space-y-3" data-testid="all-assessments-list">
-              {assessments.map((a) => (
-                <div key={a.id} className="border border-gray-200 rounded-lg p-4 flex justify-between items-center" data-testid={`admin-assessment-${a.id}`}>
-                  <div>
-                    <p className="font-medium text-gray-900">Code: {a.join_code}</p>
-                    <p className="text-sm text-gray-600">Teacher: {a.teacher_name}</p>
-                    <p className="text-sm text-gray-500">Status: {a.status}</p>
+        {/* Assessments tab */}
+        {activeTab === 'assessments' && (
+          <div className="bg-white p-6 rounded-lg shadow">
+            <h3 className="text-xl font-semibold text-gray-900 mb-4" data-testid="all-assessments-title">
+              All Assessments ({assessments.length})
+            </h3>
+            {loading ? (
+              <div className="text-center py-8">Loading...</div>
+            ) : assessments.length === 0 ? (
+              <p className="text-gray-600 text-center py-8">No assessments yet</p>
+            ) : (
+              <div className="space-y-3" data-testid="all-assessments-list">
+                {assessments.map((a) => (
+                  <div key={a.id} className="border border-gray-200 rounded-lg p-4 flex justify-between items-center" data-testid={`admin-assessment-${a.id}`}>
+                    <div>
+                      <p className="font-medium text-gray-900">Code: {a.join_code}</p>
+                      <p className="text-sm text-gray-600">Teacher: {a.teacher_name}</p>
+                      <p className="text-sm text-gray-500">Status: {a.status}</p>
+                    </div>
+                    <button
+                      onClick={() => navigate(`/teacher/assessments/${a.id}`)}
+                      className="bg-blue-600 text-white py-1 px-3 rounded text-sm hover:bg-blue-700"
+                      data-testid={`view-assessment-${a.id}`}
+                    >
+                      View
+                    </button>
                   </div>
-                  <button
-                    onClick={() => navigate(`/teacher/assessments/${a.id}`)}
-                    className="bg-blue-600 text-white py-1 px-3 rounded text-sm hover:bg-blue-700"
-                    data-testid={`view-assessment-${a.id}`}
-                  >
-                    View
-                  </button>
-                </div>
-              ))}
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Usage & Quotas tab */}
+        {activeTab === 'usage' && (
+          <div className="bg-white rounded-lg shadow overflow-hidden">
+            <div className="px-6 py-4 border-b flex items-center justify-between">
+              <h3 className="text-xl font-semibold text-gray-900">Usage &amp; Quotas</h3>
+              <button
+                onClick={loadUsage}
+                className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+              >
+                Refresh
+              </button>
             </div>
-          )}
-        </div>
+
+            {usageLoading ? (
+              <div className="text-center py-12 text-gray-500">Loading usage data...</div>
+            ) : usageData.length === 0 ? (
+              <div className="text-center py-12 text-gray-500">No usage data found</div>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-gray-50">
+                      <th className="text-left py-3 px-4 text-gray-600 font-medium">User</th>
+                      <th className="text-left py-3 px-4 text-gray-600 font-medium">Plan</th>
+                      <th className="text-left py-3 px-4 text-gray-600 font-medium">Trial Ends</th>
+                      <th className="text-left py-3 px-4 text-gray-600 font-medium">OCR Pages</th>
+                      <th className="text-left py-3 px-4 text-gray-600 font-medium">AI Marking</th>
+                      <th className="text-left py-3 px-4 text-gray-600 font-medium">PDF Exports</th>
+                      <th className="text-left py-3 px-4 text-gray-600 font-medium">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {usageData.map(entry => {
+                      const { user: u, quota, raw_quota } = entry;
+                      const expired = quota.trial_expired;
+                      return (
+                        <tr key={u.user_id} className={`border-b hover:bg-gray-50 ${expired ? 'bg-red-50' : ''}`}>
+                          <td className="py-3 px-4">
+                            <p className="font-medium text-gray-900">{u.name}</p>
+                            <p className="text-xs text-gray-500">{u.email}</p>
+                          </td>
+                          <td className="py-3 px-4">
+                            <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${ACCOUNT_TYPE_COLORS[quota.account_type] || 'bg-gray-100 text-gray-700'}`}>
+                              {ACCOUNT_TYPE_LABELS[quota.account_type] || quota.account_type}
+                            </span>
+                            {expired && (
+                              <span className="ml-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">Expired</span>
+                            )}
+                          </td>
+                          <td className="py-3 px-4 text-gray-600">
+                            {quota.trial_end_date
+                              ? new Date(quota.trial_end_date).toLocaleDateString()
+                              : '—'}
+                            {!expired && quota.days_remaining !== null && (
+                              <span className={`ml-1 text-xs ${quota.days_remaining <= 5 ? 'text-amber-600 font-medium' : 'text-gray-400'}`}>
+                                ({quota.days_remaining}d)
+                              </span>
+                            )}
+                          </td>
+                          <td className="py-3 px-4">
+                            {quota.is_unlimited
+                              ? <span className="text-green-600 text-xs font-medium">Unlimited</span>
+                              : <QuotaBar used={quota.ocr_pages_used} allowance={quota.ocr_pages_allowance} />}
+                          </td>
+                          <td className="py-3 px-4">
+                            {quota.is_unlimited
+                              ? <span className="text-green-600 text-xs font-medium">Unlimited</span>
+                              : <QuotaBar used={quota.ai_marking_runs_used} allowance={quota.ai_marking_allowance} />}
+                          </td>
+                          <td className="py-3 px-4">
+                            {quota.is_unlimited
+                              ? <span className="text-green-600 text-xs font-medium">Unlimited</span>
+                              : <QuotaBar used={quota.pdf_exports_used} allowance={quota.pdf_export_allowance} />}
+                          </td>
+                          <td className="py-3 px-4">
+                            <button
+                              onClick={() => setEditingEntry(entry)}
+                              className="text-blue-600 hover:text-blue-700 font-medium text-xs"
+                            >
+                              Edit
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
       </div>
+
+      {editingEntry && (
+        <UsageEditModal
+          entry={editingEntry}
+          onClose={() => setEditingEntry(null)}
+          onSave={() => {
+            setEditingEntry(null);
+            loadUsage();
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/AnalyticsPage.js
+++ b/src/components/AnalyticsPage.js
@@ -936,6 +936,355 @@ const MathAnalyticsPanel = ({ classes, assessments }) => {
   );
 };
 
+// ── Costs Panel ─────────────────────────────────────────────────────────────
+
+const ACCOUNT_TYPE_LABELS = {
+  free_tester: 'Free Trial',
+  paid: 'Paid',
+  starter: 'Starter',
+  professional: 'Professional',
+  department: 'Department',
+  school: 'School',
+  enterprise: 'Enterprise',
+  extended: 'Extended',
+  pilot: 'Pilot',
+  internal: 'Internal',
+};
+
+// AI cost rates (£ per unit, mid-range estimates)
+const COST_RATES = {
+  ocr_per_page: 0.02,       // £0.02 per OCR page (GPT-4o Vision)
+  marking_per_run: 0.02,    // £0.02 per AI marking run
+  pdf_per_export: 0.00,     // PDF is local — no API cost
+};
+
+function UsageMeterBar({ label, used, allowance, remaining, isUnlimited }) {
+  const pct = allowance > 0 ? Math.min(100, Math.round((used / allowance) * 100)) : 0;
+  const color = remaining === 0 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-blue-500';
+  const textColor = remaining === 0 ? 'text-red-600' : pct >= 80 ? 'text-amber-600' : 'text-blue-600';
+
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between items-center text-sm">
+        <span className="font-medium text-gray-700">{label}</span>
+        {isUnlimited ? (
+          <span className="text-teal-600 font-semibold">Unlimited</span>
+        ) : (
+          <span className={`font-semibold ${textColor}`}>
+            {used.toLocaleString()} / {allowance.toLocaleString()}
+            <span className="text-gray-400 font-normal ml-1">({remaining.toLocaleString()} left)</span>
+          </span>
+        )}
+      </div>
+      {!isUnlimited && (
+        <div className="h-2.5 bg-gray-200 rounded-full overflow-hidden">
+          <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${pct}%` }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CostRow({ label, used, rate, sublabel }) {
+  const cost = (used * rate).toFixed(2);
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
+      <div>
+        <p className="text-sm font-medium text-gray-800">{label}</p>
+        {sublabel && <p className="text-xs text-gray-500">{sublabel}</p>}
+      </div>
+      <div className="text-right">
+        <p className="text-sm font-semibold text-gray-900">£{cost}</p>
+        <p className="text-xs text-gray-400">{used.toLocaleString()} × £{rate.toFixed(3)}</p>
+      </div>
+    </div>
+  );
+}
+
+const CostsPanel = () => {
+  const [quota, setQuota] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    axios.get(`${API}/teacher/usage`)
+      .then(r => setQuota(r.data))
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return (
+    <div className="flex items-center justify-center py-20">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mr-3" />
+      <p className="text-gray-600">Loading usage data...</p>
+    </div>
+  );
+
+  if (error || !quota) return (
+    <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-red-700 text-sm">
+      Could not load usage data. Please refresh the page.
+    </div>
+  );
+
+  const isUnlimited = quota.is_unlimited;
+
+  // Cost estimates for current month
+  const ocrCost     = quota.ocr_pages_used     * COST_RATES.ocr_per_page;
+  const markingCost = quota.ai_marking_runs_used * COST_RATES.marking_per_run;
+  const pdfCost     = 0; // local
+  const totalThisMonth = ocrCost + markingCost + pdfCost;
+
+  // Forecast: project current burn rate to full month
+  // Use trial_start_date (or created_at) to estimate days elapsed
+  const now = new Date();
+  let daysElapsed = 30;
+  if (quota.trial_end_date) {
+    const endDate = new Date(quota.trial_end_date);
+    const startDate = new Date(endDate.getTime() - 30 * 24 * 60 * 60 * 1000);
+    daysElapsed = Math.max(1, Math.round((now - startDate) / (1000 * 60 * 60 * 24)));
+  }
+  const daysInMonth = 30;
+  const burnMultiplier = daysElapsed < daysInMonth ? daysInMonth / daysElapsed : 1;
+  const forecastedMonth = totalThisMonth * burnMultiplier;
+
+  // Tier pricing map
+  const tierPricing = {
+    free_tester: 0, starter: 19, professional: 39,
+    department: 149, school: 349, paid: 0, internal: 0,
+    extended: 0, pilot: 0, enterprise: 0,
+  };
+  const subscriptionCost = tierPricing[quota.account_type] ?? 0;
+  const totalBill = subscriptionCost + totalThisMonth;
+  const forecastedBill = subscriptionCost + forecastedMonth;
+
+  const trialExpired = quota.trial_expired;
+  const trialWarning = !trialExpired && quota.days_remaining !== null && quota.days_remaining <= 7;
+
+  return (
+    <div className="space-y-6">
+
+      {/* Trial status banner */}
+      {trialExpired && (
+        <div className="bg-red-50 border border-red-300 rounded-lg p-4 flex items-start gap-3">
+          <div className="text-red-500 text-xl">⚠</div>
+          <div>
+            <p className="font-semibold text-red-700">Your free trial has expired</p>
+            <p className="text-sm text-red-600 mt-0.5">
+              You can still view existing assessments and results. Contact your admin to upgrade and restore full access.
+            </p>
+          </div>
+        </div>
+      )}
+      {trialWarning && (
+        <div className="bg-amber-50 border border-amber-300 rounded-lg p-4 flex items-start gap-3">
+          <div className="text-amber-500 text-xl">⏳</div>
+          <div>
+            <p className="font-semibold text-amber-700">
+              {quota.days_remaining === 0 ? 'Your trial expires today' : `${quota.days_remaining} day${quota.days_remaining !== 1 ? 's' : ''} left on your free trial`}
+            </p>
+            <p className="text-sm text-amber-600 mt-0.5">Upgrade to keep uninterrupted access after your trial ends.</p>
+          </div>
+        </div>
+      )}
+
+      {/* Account & subscription */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-xl font-semibold text-gray-900 mb-1">Account &amp; Subscription</h3>
+        <p className="text-sm text-gray-500 mb-5">Your current plan and billing commitments</p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="bg-blue-50 rounded-lg p-4">
+            <p className="text-xs text-blue-600 font-medium uppercase tracking-wide mb-1">Current Plan</p>
+            <p className="text-2xl font-bold text-blue-800">{ACCOUNT_TYPE_LABELS[quota.account_type] || quota.account_type}</p>
+            {subscriptionCost > 0 && (
+              <p className="text-sm text-blue-600 mt-1">£{subscriptionCost}/month</p>
+            )}
+            {subscriptionCost === 0 && !isUnlimited && (
+              <p className="text-sm text-blue-600 mt-1">No subscription cost</p>
+            )}
+            {isUnlimited && (
+              <p className="text-sm text-teal-600 font-medium mt-1">Unlimited usage</p>
+            )}
+          </div>
+          <div className="bg-green-50 rounded-lg p-4">
+            <p className="text-xs text-green-600 font-medium uppercase tracking-wide mb-1">This Month's Bill</p>
+            <p className="text-2xl font-bold text-green-800">£{totalBill.toFixed(2)}</p>
+            <p className="text-xs text-green-600 mt-1">
+              £{subscriptionCost.toFixed(2)} subscription + £{totalThisMonth.toFixed(2)} usage
+            </p>
+          </div>
+          <div className="bg-purple-50 rounded-lg p-4">
+            <p className="text-xs text-purple-600 font-medium uppercase tracking-wide mb-1">Next Month Forecast</p>
+            <p className="text-2xl font-bold text-purple-800">£{forecastedBill.toFixed(2)}</p>
+            <p className="text-xs text-purple-600 mt-1">Based on {daysElapsed} day{daysElapsed !== 1 ? 's' : ''} of usage so far</p>
+          </div>
+        </div>
+
+        {quota.trial_end_date && !isUnlimited && (
+          <div className="mt-4 pt-4 border-t border-gray-100 flex items-center justify-between text-sm">
+            <span className="text-gray-500">
+              {trialExpired ? 'Trial ended' : 'Trial ends'}:{' '}
+              <span className={`font-medium ${trialExpired ? 'text-red-600' : trialWarning ? 'text-amber-600' : 'text-gray-700'}`}>
+                {new Date(quota.trial_end_date).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })}
+              </span>
+            </span>
+            {!isUnlimited && quota.account_type === 'free_tester' && !trialExpired && (
+              <span className="text-blue-600 font-medium">
+                {quota.days_remaining !== null ? `${quota.days_remaining} day${quota.days_remaining !== 1 ? 's' : ''} remaining` : ''}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Usage meters */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-xl font-semibold text-gray-900 mb-1">Usage This Period</h3>
+        <p className="text-sm text-gray-500 mb-5">Consumption against your plan limits</p>
+        <div className="space-y-5">
+          <UsageMeterBar
+            label="AI Marking Runs"
+            used={quota.ai_marking_runs_used}
+            allowance={quota.ai_marking_allowance}
+            remaining={quota.ai_marking_remaining}
+            isUnlimited={isUnlimited}
+          />
+          <UsageMeterBar
+            label="OCR Pages"
+            used={quota.ocr_pages_used}
+            allowance={quota.ocr_pages_allowance}
+            remaining={quota.ocr_pages_remaining}
+            isUnlimited={isUnlimited}
+          />
+          <UsageMeterBar
+            label="PDF Exports"
+            used={quota.pdf_exports_used}
+            allowance={quota.pdf_export_allowance}
+            remaining={quota.pdf_exports_remaining}
+            isUnlimited={isUnlimited}
+          />
+        </div>
+
+        {!isUnlimited && (
+          <div className="mt-5 pt-4 border-t border-gray-100 grid grid-cols-3 gap-4 text-center text-xs text-gray-500">
+            <div>
+              <p className="text-lg font-bold text-gray-800">{quota.max_assessments}</p>
+              <p>Max assessments</p>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-gray-800">{quota.max_classes}</p>
+              <p>Max classes</p>
+            </div>
+            <div>
+              <p className="text-lg font-bold text-gray-800">{quota.days_remaining ?? '—'}</p>
+              <p>Days remaining</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Cost breakdown */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-xl font-semibold text-gray-900 mb-1">Cost Breakdown</h3>
+        <p className="text-sm text-gray-500 mb-5">
+          Estimated AI processing costs based on your usage.
+          {isUnlimited ? ' Your plan absorbs these costs.' : ' These costs are covered by your subscription.'}
+        </p>
+
+        <div className="divide-y divide-gray-100">
+          <CostRow
+            label="AI Marking"
+            used={quota.ai_marking_runs_used}
+            rate={COST_RATES.marking_per_run}
+            sublabel={`${quota.ai_marking_runs_used.toLocaleString()} submission${quota.ai_marking_runs_used !== 1 ? 's' : ''} marked`}
+          />
+          <CostRow
+            label="OCR Processing"
+            used={quota.ocr_pages_used}
+            rate={COST_RATES.ocr_per_page}
+            sublabel={`${quota.ocr_pages_used.toLocaleString()} page${quota.ocr_pages_used !== 1 ? 's' : ''} processed (includes past paper extraction)`}
+          />
+          <div className="flex items-center justify-between py-2">
+            <div>
+              <p className="text-sm font-medium text-gray-800">PDF Report Generation</p>
+              <p className="text-xs text-gray-500">{quota.pdf_exports_used.toLocaleString()} export{quota.pdf_exports_used !== 1 ? 's' : ''} — generated locally, no API cost</p>
+            </div>
+            <div className="text-right">
+              <p className="text-sm font-semibold text-gray-900">£0.00</p>
+              <p className="text-xs text-gray-400">Included</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 pt-4 border-t border-gray-200 flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-gray-600">Total AI costs this period</p>
+            <p className="text-xs text-gray-400">Subscription fee not included</p>
+          </div>
+          <p className="text-xl font-bold text-gray-900">£{totalThisMonth.toFixed(2)}</p>
+        </div>
+
+        {subscriptionCost > 0 && (
+          <div className="mt-3 flex items-center justify-between bg-blue-50 rounded-lg px-4 py-3">
+            <div>
+              <p className="text-sm font-medium text-blue-800">Subscription ({ACCOUNT_TYPE_LABELS[quota.account_type]})</p>
+              <p className="text-xs text-blue-600">Monthly recurring charge</p>
+            </div>
+            <p className="text-lg font-bold text-blue-800">£{subscriptionCost.toFixed(2)}</p>
+          </div>
+        )}
+
+        <div className="mt-3 flex items-center justify-between bg-gray-800 text-white rounded-lg px-4 py-3">
+          <p className="font-semibold">Total estimated this month</p>
+          <p className="text-xl font-bold">£{totalBill.toFixed(2)}</p>
+        </div>
+
+        <p className="text-xs text-gray-400 mt-3">
+          Cost estimates: AI marking ~£0.02/run, OCR ~£0.02/page (GPT-4o Vision, mid-range). Actual API costs may vary with usage patterns. Figures are indicative only.
+        </p>
+      </div>
+
+      {/* Forecast */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-xl font-semibold text-gray-900 mb-1">Next Month Forecast</h3>
+        <p className="text-sm text-gray-500 mb-5">Projected usage based on your current burn rate ({daysElapsed} days of data)</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-5">
+          {[
+            { label: 'Forecasted AI Marking', count: Math.round(quota.ai_marking_runs_used * burnMultiplier), unit: 'runs', cost: Math.round(quota.ai_marking_runs_used * burnMultiplier) * COST_RATES.marking_per_run },
+            { label: 'Forecasted OCR Pages', count: Math.round(quota.ocr_pages_used * burnMultiplier), unit: 'pages', cost: Math.round(quota.ocr_pages_used * burnMultiplier) * COST_RATES.ocr_per_page },
+            { label: 'Forecasted PDF Exports', count: Math.round(quota.pdf_exports_used * burnMultiplier), unit: 'exports', cost: 0 },
+          ].map(({ label, count, unit, cost }) => (
+            <div key={label} className="border border-gray-200 rounded-lg p-4">
+              <p className="text-xs text-gray-500 mb-1">{label}</p>
+              <p className="text-2xl font-bold text-gray-800">{count.toLocaleString()}</p>
+              <p className="text-xs text-gray-500 mt-0.5">{unit} · est. £{cost.toFixed(2)}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between bg-purple-50 rounded-lg px-4 py-3">
+          <div>
+            <p className="font-semibold text-purple-800">Forecasted total next month</p>
+            <p className="text-xs text-purple-600">Subscription + projected AI costs</p>
+          </div>
+          <p className="text-xl font-bold text-purple-800">£{forecastedBill.toFixed(2)}</p>
+        </div>
+
+        {!isUnlimited && quota.account_type === 'free_tester' && (
+          <div className="mt-4 bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <p className="text-sm font-semibold text-blue-800 mb-1">Ready to upgrade?</p>
+            <p className="text-sm text-blue-700">
+              The <strong>Starter plan</strong> at £19/month gives you 300 AI marking runs, 150 OCR pages, and 100 PDF exports —
+              perfect for a solo teacher. <strong>Professional</strong> at £39/month covers up to 1,000 marking runs and 500 OCR pages.
+            </p>
+          </div>
+        )}
+      </div>
+
+    </div>
+  );
+};
+
 // Main Analytics Page
 export const AnalyticsPage = ({ user }) => {
   const navigate = useNavigate();
@@ -1131,12 +1480,22 @@ export const AnalyticsPage = ({ user }) => {
           <button
             onClick={() => setActiveTab('support')}
             className={`px-4 py-2 font-medium border-b-2 transition-colors ${
-              activeTab === 'support' 
-                ? 'border-blue-600 text-blue-600' 
+              activeTab === 'support'
+                ? 'border-blue-600 text-blue-600'
                 : 'border-transparent text-gray-600 hover:text-gray-900'
             }`}
           >
             Intervention Support
+          </button>
+          <button
+            onClick={() => setActiveTab('costs')}
+            className={`px-4 py-2 font-medium border-b-2 transition-colors ${
+              activeTab === 'costs'
+                ? 'border-blue-600 text-blue-600'
+                : 'border-transparent text-gray-600 hover:text-gray-900'
+            }`}
+          >
+            Costs
           </button>
         </div>
 
@@ -1161,13 +1520,15 @@ export const AnalyticsPage = ({ user }) => {
         )}
 
         {activeTab === 'support' && (
-          <ClassSupportPanel 
+          <ClassSupportPanel
             overview={overview}
             aiInsights={aiInsights}
             onGenerateInsights={generateInsights}
             loading={insightsLoading}
           />
         )}
+
+        {activeTab === 'costs' && <CostsPanel />}
       </div>
 
       {/* Student Profile Modal */}

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -19,6 +19,7 @@ import {
   FileText,
   CheckSquare,
   BarChart3,
+  ShieldCheck,
   ChevronDown,
   Menu,
   X,
@@ -128,6 +129,20 @@ export const Navbar = ({ user, onLogout }) => {
                     </button>
                   );
                 })}
+                {user?.role === 'admin' && (
+                  <button
+                    onClick={() => navigate('/admin/dashboard')}
+                    data-testid="nav-admin"
+                    className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                      location.pathname.startsWith('/admin')
+                        ? 'text-purple-700 bg-purple-50'
+                        : 'text-purple-600 hover:text-purple-800 hover:bg-purple-50'
+                    }`}
+                  >
+                    <ShieldCheck className="w-4 h-4" />
+                    Admin
+                  </button>
+                )}
               </nav>
             </div>
 
@@ -168,6 +183,16 @@ export const Navbar = ({ user, onLogout }) => {
                     <User className="w-4 h-4 mr-2" />
                     Profile & Settings
                   </DropdownMenuItem>
+                  {user?.role === 'admin' && (
+                    <DropdownMenuItem
+                      onClick={() => navigate('/admin/dashboard')}
+                      data-testid="dropdown-admin"
+                      className="text-purple-700 focus:text-purple-700 focus:bg-purple-50"
+                    >
+                      <ShieldCheck className="w-4 h-4 mr-2" />
+                      Admin Panel
+                    </DropdownMenuItem>
+                  )}
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     onClick={handleLogout}
@@ -229,6 +254,25 @@ export const Navbar = ({ user, onLogout }) => {
                   </button>
                 );
               })}
+
+              {/* Admin link — mobile, only for admins */}
+              {user?.role === 'admin' && (
+                <button
+                  onClick={() => {
+                    navigate('/admin/dashboard');
+                    setMobileOpen(false);
+                  }}
+                  data-testid="mobile-nav-admin"
+                  className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+                    location.pathname.startsWith('/admin')
+                      ? 'text-purple-700 bg-purple-50'
+                      : 'text-purple-600 hover:bg-purple-50'
+                  }`}
+                >
+                  <ShieldCheck className="w-5 h-5" />
+                  Admin Panel
+                </button>
+              )}
 
               {/* Mobile profile block */}
               <div className="pt-3 mt-3 border-t border-gray-100">

--- a/src/components/UsageBanner.js
+++ b/src/components/UsageBanner.js
@@ -1,0 +1,134 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import axios from 'axios';
+import { API } from '@/config';
+
+const ACCOUNT_TYPE_LABELS = {
+  free_tester: 'Free Trial',
+  paid: 'Paid',
+  extended: 'Extended',
+  pilot: 'Pilot',
+  internal: 'Internal',
+};
+
+function UsageMeter({ label, used, allowance, remaining, warning }) {
+  const pct = allowance > 0 ? Math.min(100, Math.round((used / allowance) * 100)) : 0;
+  const color =
+    remaining === 0 ? 'bg-red-500' :
+    pct >= 80 ? 'bg-amber-500' :
+    'bg-blue-500';
+
+  return (
+    <div className="flex-1 min-w-[140px]">
+      <div className="flex justify-between items-center mb-1">
+        <span className="text-xs font-medium text-gray-600">{label}</span>
+        <span className={`text-xs font-semibold ${remaining === 0 ? 'text-red-600' : pct >= 80 ? 'text-amber-600' : 'text-gray-700'}`}>
+          {remaining} left
+        </span>
+      </div>
+      <div className="h-1.5 bg-gray-200 rounded-full overflow-hidden">
+        <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      {warning && (
+        <p className="text-xs text-amber-600 mt-0.5">{warning}</p>
+      )}
+    </div>
+  );
+}
+
+export default function UsageBanner() {
+  const [quota, setQuota] = useState(null);
+  const [dismissed, setDismissed] = useState(false);
+  const [error, setError] = useState(false);
+
+  const loadQuota = useCallback(async () => {
+    try {
+      const res = await axios.get(`${API}/teacher/usage`);
+      setQuota(res.data);
+    } catch {
+      setError(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadQuota();
+  }, [loadQuota]);
+
+  if (dismissed || error || !quota) return null;
+
+  // Unlimited accounts — show a simple badge, no meters
+  if (quota.is_unlimited) {
+    return (
+      <div className="bg-green-50 border border-green-200 rounded-lg px-4 py-2 flex items-center justify-between text-sm mb-4">
+        <span className="text-green-700 font-medium">
+          {ACCOUNT_TYPE_LABELS[quota.account_type] || quota.account_type} account — unlimited usage
+        </span>
+        <button onClick={() => setDismissed(true)} className="text-green-500 hover:text-green-700 ml-4">✕</button>
+      </div>
+    );
+  }
+
+  const anyLimitReached = quota.ocr_pages_remaining === 0 || quota.ai_marking_remaining === 0 || quota.pdf_exports_remaining === 0;
+  const trialExpired = quota.trial_expired;
+  const trialWarning = !trialExpired && quota.days_remaining !== null && quota.days_remaining <= 5;
+
+  if (trialExpired) {
+    return (
+      <div className="bg-red-50 border border-red-300 rounded-lg px-4 py-3 flex items-start justify-between mb-4">
+        <div>
+          <p className="text-red-700 font-semibold text-sm">Your free tester access has ended.</p>
+          <p className="text-red-600 text-xs mt-0.5">
+            You can still view existing assessments and results. Contact your admin to request an extension.
+          </p>
+        </div>
+        <button onClick={() => setDismissed(true)} className="text-red-400 hover:text-red-600 ml-4 mt-0.5">✕</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`rounded-lg border px-4 py-3 mb-4 ${anyLimitReached ? 'bg-red-50 border-red-200' : trialWarning ? 'bg-amber-50 border-amber-200' : 'bg-gray-50 border-gray-200'}`}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${anyLimitReached ? 'bg-red-100 text-red-700' : 'bg-blue-100 text-blue-700'}`}>
+            {ACCOUNT_TYPE_LABELS[quota.account_type] || quota.account_type}
+          </span>
+          {quota.days_remaining !== null && (
+            <span className={`text-xs ${trialWarning ? 'text-amber-600 font-medium' : 'text-gray-500'}`}>
+              {quota.days_remaining === 0
+                ? 'Trial expires today'
+                : `${quota.days_remaining} day${quota.days_remaining !== 1 ? 's' : ''} remaining`}
+            </span>
+          )}
+        </div>
+        <button onClick={() => setDismissed(true)} className="text-gray-400 hover:text-gray-600 text-sm">✕</button>
+      </div>
+
+      <div className="flex gap-4 flex-wrap">
+        <UsageMeter
+          label="OCR Pages"
+          used={quota.ocr_pages_used}
+          allowance={quota.ocr_pages_allowance}
+          remaining={quota.ocr_pages_remaining}
+        />
+        <UsageMeter
+          label="AI Marking"
+          used={quota.ai_marking_runs_used}
+          allowance={quota.ai_marking_allowance}
+          remaining={quota.ai_marking_remaining}
+        />
+        <UsageMeter
+          label="PDF Exports"
+          used={quota.pdf_exports_used}
+          allowance={quota.pdf_export_allowance}
+          remaining={quota.pdf_exports_remaining}
+        />
+      </div>
+
+      {anyLimitReached && (
+        <p className="text-xs text-red-600 mt-2">
+          One or more limits reached. Contact your admin to extend your allowance.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/TeacherDashboardPage.js
+++ b/src/pages/TeacherDashboardPage.js
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { API } from '@/config';
 import { Navbar } from '../components/Navbar';
+import UsageBanner from '../components/UsageBanner';
 import {
   ClipboardList, Upload, Eye, PenLine, BarChart3,
   AlertTriangle, CheckCircle2, ChevronRight, RefreshCw,
@@ -191,6 +192,8 @@ export const TeacherDashboard = ({ user }) => {
       <Navbar user={user} />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-6">
+
+        <UsageBanner />
 
         {/* ── Hero panel ── */}
         <div className="relative overflow-hidden rounded-2xl shadow-sm px-6 sm:px-8 py-8 sm:py-10 flex flex-col lg:flex-row items-start lg:items-center justify-between gap-6 lg:gap-10"


### PR DESCRIPTION
Added:
- Usage banner on the teacher dashboard showing OCR, AI marking, and PDF progress bars with colour-coded warnings
Costs tab in Analytics — shows current usage meters, itemised cost breakdown, this month's bill estimate, and next-month forecast
- Admin nav link in the top bar, mobile menu, and profile dropdown — only visible to admin users, links to `/admin/dashboard`

Updated:
- Admin Dashboard redesigned with three tabs: Teachers (role management), Assessments (all assessments), and Usage & Quotas (quota editing with progress bars and an edit modal per teacher)

Screenshots:
<img width="1247" height="90" alt="image" src="https://github.com/user-attachments/assets/e7ebfbb3-c07e-497d-9bc4-ba297750d494" />

<img width="1859" height="720" alt="image" src="https://github.com/user-attachments/assets/e753dda6-2f40-48fe-9fb3-3908da46cd18" />

<img width="1246" height="906" alt="image" src="https://github.com/user-attachments/assets/4b513e8d-659c-4dc7-92a1-6a734a7b4843" />

<img width="1235" height="910" alt="image" src="https://github.com/user-attachments/assets/6ab51b16-0331-4604-8b57-327a69bb2f30" />
